### PR TITLE
adding obis support to metadata-conversion

### DIFF
--- a/cioos_metadata_conversion/__main__.py
+++ b/cioos_metadata_conversion/__main__.py
@@ -99,7 +99,7 @@ def convert(
     """Convert metadata records to different metadata formats or standards."""
 
     logger.info("Loading input {}", input)
-    if input.startswith("http"):
+    if input.startswith("http") or input_schema in ["doi", "obis"]:
         files = [input]
     else:
         files = glob(input, recursive=recursive)
@@ -143,7 +143,7 @@ def convert(
             output_file.write_text(converted_record, encoding=output_encoding)
         else:
             returned_output += "\n" + converted_record
-    
+
     if not output_file:
         logger.info("Returning converted output")
         print(returned_output)

--- a/cioos_metadata_conversion/firebase_to_cioos.py
+++ b/cioos_metadata_conversion/firebase_to_cioos.py
@@ -87,11 +87,54 @@ def verify_translation(verified, message):
     return ""
 
 
+def _sanitize_keyword_list(keyword_list):
+    """Split and clean a list of keywords.
+
+    Handles common issues that cause CKAN tag validation failures:
+    - Keywords joined by '|', '\n', or '>' are split into separate entries.
+    - HTML entities like '&gt;' are decoded before splitting.
+    - Only characters allowed by CKAN tags are kept:
+      alphanumeric, spaces, and the symbols  - _ . , ; ' ( )
+    """
+    import html
+    import re
+
+    cleaned = []
+    for keyword in keyword_list:
+        if not isinstance(keyword, str):
+            continue
+        # Decode HTML entities (e.g. &gt; -> >)
+        keyword = html.unescape(keyword)
+        # Split on common delimiters: |, >, and newlines
+        parts = re.split(r"[|>\n]+", keyword)
+        for part in parts:
+            # Strip whitespace
+            part = part.strip()
+            # Remove characters not allowed by CKAN tag validation
+            part = re.sub(r"[^\w\s\-_.,;'()/]", "", part, flags=re.UNICODE)
+            # Collapse multiple spaces
+            part = re.sub(r"\s+", " ", part).strip()
+            if part:
+                cleaned.append(part)
+    # Deduplicate while preserving order
+    seen = set()
+    deduped = []
+    for kw in cleaned:
+        if kw not in seen:
+            seen.add(kw)
+            deduped.append(kw)
+    return deduped
+
+
 def strip_keywords(keywords):
-    """Strips whitespace from each keyword in either language"""
+    """Strips whitespace and sanitizes each keyword in either language.
+
+    Splits keywords on '|', '>', and newlines, removes characters
+    not allowed by CKAN, and deduplicates.
+    """
     stripped = {
-        "en": [keyword.strip() for keyword in keywords.get("en", [])],
-        "fr": [keyword.strip() for keyword in keywords.get("fr", [])],
+        "en": _sanitize_keyword_list(keywords.get("en", [])),
+        "fr": _sanitize_keyword_list(keywords.get("fr", [])),
     }
 
     return scrub_keys(stripped)

--- a/cioos_metadata_conversion/load_from/obis.py
+++ b/cioos_metadata_conversion/load_from/obis.py
@@ -1,14 +1,17 @@
+import re
+
 import requests
 from loguru import logger
 
 OBIS_API_BASE = "https://api.obis.org/v3/dataset"
 OBIS_FACET_URL = "https://api.obis.org/v3/facet"
+OBIS_OCCURRENCE_URL = "https://api.obis.org/v3/occurrence"
 
 # Mapping from OBIS taxonomic class names to CIOOS Essential Ocean Variables.
 # Built from the OBIS /v3/facet?facets=class endpoint values and the CIOOS
 # EOV choices in cioos-siooc_schema.json.
 TAXON_CLASS_TO_EOV = {
-    # Fish — fishAbundanceAndDistribution
+    # ── Fish — fishAbundanceAndDistribution ──
     "Actinopterygii": "fishAbundanceAndDistribution",
     "Teleostei": "fishAbundanceAndDistribution",
     "Elasmobranchii": "fishAbundanceAndDistribution",
@@ -18,11 +21,14 @@ TAXON_CLASS_TO_EOV = {
     "Holocephali": "fishAbundanceAndDistribution",
     "Chondrostei": "fishAbundanceAndDistribution",
     "Ichthyostraca": "fishAbundanceAndDistribution",
-    # Marine turtles, birds, mammals
+    "Holostei": "fishAbundanceAndDistribution",
+    "Coelacanthi": "fishAbundanceAndDistribution",
+    "Dipneusti": "fishAbundanceAndDistribution",
+    # ── Marine turtles, birds, mammals ──
     "Mammalia": "marineTurtlesBirdsMammalsAbundanceAndDistribution",
     "Aves": "marineTurtlesBirdsMammalsAbundanceAndDistribution",
     "Reptilia": "marineTurtlesBirdsMammalsAbundanceAndDistribution",
-    # Phytoplankton
+    # ── Phytoplankton — photosynthetic algae & cyanobacteria ──
     "Bacillariophyceae": "phytoplanktonBiomassAndDiversity",
     "Dinophyceae": "phytoplanktonBiomassAndDiversity",
     "Coscinodiscophyceae": "phytoplanktonBiomassAndDiversity",
@@ -43,7 +49,25 @@ TAXON_CLASS_TO_EOV = {
     "Chlorodendrophyceae": "phytoplanktonBiomassAndDiversity",
     "Trebouxiophyceae": "phytoplanktonBiomassAndDiversity",
     "Zygnematophyceae": "phytoplanktonBiomassAndDiversity",
-    # Zooplankton (includes many protist microzooplankton & foraminifera groups)
+    # New phytoplankton additions (from OBIS facet data)
+    "Pyramimonadophyceae": "phytoplanktonBiomassAndDiversity",
+    "Mamiellophyceae": "phytoplanktonBiomassAndDiversity",
+    "Cryptophyta incertae sedis": "phytoplanktonBiomassAndDiversity",
+    "Pelagophyceae": "phytoplanktonBiomassAndDiversity",
+    "Eustigmatophyceae": "phytoplanktonBiomassAndDiversity",
+    "Bolidophyceae": "phytoplanktonBiomassAndDiversity",
+    "Pavlovophyceae": "phytoplanktonBiomassAndDiversity",
+    "Prasinodermatophyceae": "phytoplanktonBiomassAndDiversity",
+    "Nephroselmidophyceae": "phytoplanktonBiomassAndDiversity",
+    "Pinguiophyceae": "phytoplanktonBiomassAndDiversity",
+    "Synurophyceae": "phytoplanktonBiomassAndDiversity",
+    "Haptophyta incertae sedis": "phytoplanktonBiomassAndDiversity",
+    "Dinoflagellata incertae sedis": "phytoplanktonBiomassAndDiversity",
+    "Chlorarachnea": "phytoplanktonBiomassAndDiversity",
+    "Chlorarachniophyceae": "phytoplanktonBiomassAndDiversity",
+    "Glaucophyceae": "phytoplanktonBiomassAndDiversity",
+    "Charophyceae": "phytoplanktonBiomassAndDiversity",
+    # ── Zooplankton — planktonic heterotrophs, ciliates, rotifers, jellyfish ──
     "Hexanauplia": "zooplanktonBiomassAndDiversity",
     "Copepoda": "zooplanktonBiomassAndDiversity",
     "Branchiopoda": "zooplanktonBiomassAndDiversity",
@@ -64,7 +88,27 @@ TAXON_CLASS_TO_EOV = {
     "Monothalamea": "zooplanktonBiomassAndDiversity",
     "Tubulinea": "zooplanktonBiomassAndDiversity",
     "Foraminifera incertae sedis": "zooplanktonBiomassAndDiversity",
-    # Microbes
+    # New zooplankton additions (from OBIS facet data)
+    "Polycystina": "zooplanktonBiomassAndDiversity",     # Radiolaria
+    "Litostomatea": "zooplanktonBiomassAndDiversity",     # Ciliates
+    "Spirotrichea": "zooplanktonBiomassAndDiversity",     # Ciliates (tintinnids etc.)
+    "Acantharia": "zooplanktonBiomassAndDiversity",       # Planktonic protists
+    "Eurotatoria": "zooplanktonBiomassAndDiversity",      # Rotifers
+    "Phyllopharyngea": "zooplanktonBiomassAndDiversity",  # Ciliates
+    "Nassophorea": "zooplanktonBiomassAndDiversity",      # Ciliates
+    "Telonemea": "zooplanktonBiomassAndDiversity",        # Heterotrophic flagellates
+    "Maxillopoda": "zooplanktonBiomassAndDiversity",      # Crustaceans (planktonic)
+    "Colpodea": "zooplanktonBiomassAndDiversity",         # Ciliates
+    "Karyorelictea": "zooplanktonBiomassAndDiversity",    # Ciliates
+    "Nuda": "zooplanktonBiomassAndDiversity",             # Ctenophores (comb jellies)
+    "Cubozoa": "zooplanktonBiomassAndDiversity",          # Box jellyfish
+    "Staurozoa": "zooplanktonBiomassAndDiversity",        # Stalked jellyfish
+    "Thecofilosea": "zooplanktonBiomassAndDiversity",     # Amoeboid protists (protozooplankton)
+    "Discosea": "zooplanktonBiomassAndDiversity",         # Amoebae (protozooplankton)
+    "Sarcomonadea": "zooplanktonBiomassAndDiversity",     # Heterotrophic flagellates
+    "Plagiopylea": "zooplanktonBiomassAndDiversity",      # Ciliates
+    "Imbricatea": "zooplanktonBiomassAndDiversity",       # Cercozoan protists
+    # ── Microbes — bacteria, archaea, fungi, parasitic & heterotrophic protists ──
     "Alphaproteobacteria": "microbeBiomassAndDiversity",
     "Betaproteobacteria": "microbeBiomassAndDiversity",
     "Gammaproteobacteria": "microbeBiomassAndDiversity",
@@ -79,17 +123,79 @@ TAXON_CLASS_TO_EOV = {
     "Gemmatimonadetes(class)": "microbeBiomassAndDiversity",
     "Aquificae": "microbeBiomassAndDiversity",
     "Methanomicrobia": "microbeBiomassAndDiversity",
-    # Macroalgae
+    # New bacteria additions
+    "Verrucomicrobiae": "microbeBiomassAndDiversity",
+    "Opitutae": "microbeBiomassAndDiversity",
+    "Planctomycetacia": "microbeBiomassAndDiversity",
+    "Phycisphaerae": "microbeBiomassAndDiversity",
+    "Clostridia": "microbeBiomassAndDiversity",
+    "Bacteroidia": "microbeBiomassAndDiversity",
+    "Anaerolineae": "microbeBiomassAndDiversity",
+    "Planctomycetia": "microbeBiomassAndDiversity",
+    "Holophagae": "microbeBiomassAndDiversity",
+    "Deinococci": "microbeBiomassAndDiversity",
+    "Caldilineae": "microbeBiomassAndDiversity",
+    "Negativicutes": "microbeBiomassAndDiversity",
+    "Erysipelotrichi": "microbeBiomassAndDiversity",
+    "Nitrospira": "microbeBiomassAndDiversity",
+    "Zetaproteobacteria": "microbeBiomassAndDiversity",
+    "Synergistia": "microbeBiomassAndDiversity",
+    "Chloroflexi": "microbeBiomassAndDiversity",
+    "Mollicutes": "microbeBiomassAndDiversity",
+    "Chlamydiia": "microbeBiomassAndDiversity",
+    "Fusobacteria": "microbeBiomassAndDiversity",
+    "Acidobacteria": "microbeBiomassAndDiversity",
+    "Fibrobacteres(class)": "microbeBiomassAndDiversity",
+    "Spirochaetes(Class)": "microbeBiomassAndDiversity",
+    "Thermomicrobia": "microbeBiomassAndDiversity",
+    "Bacteroidetes incertae sedis": "microbeBiomassAndDiversity",
+    # New archaea additions
+    "Thermoplasmata": "microbeBiomassAndDiversity",
+    "Thaumarchaeota incertae sedis": "microbeBiomassAndDiversity",
+    "Halobacteria": "microbeBiomassAndDiversity",
+    "Thermococci": "microbeBiomassAndDiversity",
+    "Thermoprotei": "microbeBiomassAndDiversity",
+    "Methanobacteria": "microbeBiomassAndDiversity",
+    "Nanoarchaeia": "microbeBiomassAndDiversity",
+    "Archaeoglobi": "microbeBiomassAndDiversity",
+    "Methanococci": "microbeBiomassAndDiversity",
+    # Fungi — marine fungi are microbes per NOAA/NIH/GOOS definitions
+    "Dothideomycetes": "microbeBiomassAndDiversity",
+    "Agaricomycetes": "microbeBiomassAndDiversity",
+    "Sordariomycetes": "microbeBiomassAndDiversity",
+    "Eurotiomycetes": "microbeBiomassAndDiversity",
+    "Tremellomycetes": "microbeBiomassAndDiversity",
+    "Saccharomycetes": "microbeBiomassAndDiversity",
+    "Leotiomycetes": "microbeBiomassAndDiversity",
+    "Microbotryomycetes": "microbeBiomassAndDiversity",
+    "Lecanoromycetes": "microbeBiomassAndDiversity",
+    "Chytridiomycetes": "microbeBiomassAndDiversity",
+    "Cystobasidiomycetes": "microbeBiomassAndDiversity",
+    "Glomeromycetes": "microbeBiomassAndDiversity",
+    "Taphrinomycetes": "microbeBiomassAndDiversity",
+    "Pezizomycetes": "microbeBiomassAndDiversity",
+    "Orbiliomycetes": "microbeBiomassAndDiversity",
+    "Wallemiomycetes": "microbeBiomassAndDiversity",
+    "Ustilaginomycetes": "microbeBiomassAndDiversity",
+    "Agaricostilbomycetes": "microbeBiomassAndDiversity",
+    # Heterotrophic / parasitic protists — eukaryotic microbes
+    "Labyrinthulea": "microbeBiomassAndDiversity",        # Thraustochytrids (decomposers)
+    "Conoidasida": "microbeBiomassAndDiversity",           # Apicomplexa parasites
+    "Perkinsea": "microbeBiomassAndDiversity",             # Parasitic protists (mollusc pathogens)
+    "Kinetoplastea": "microbeBiomassAndDiversity",         # Flagellates (incl. parasites)
+    "Diplonemea": "microbeBiomassAndDiversity",            # Heterotrophic flagellates
+    "Peronosporea": "microbeBiomassAndDiversity",          # Oomycetes
+    # ── Macroalgae ──
     "Phaeophyceae": "macroalgalCanopyCoverAndComposition",
     "Florideophyceae": "macroalgalCanopyCoverAndComposition",
     "Ulvophyceae": "macroalgalCanopyCoverAndComposition",
     "Bangiophyceae": "macroalgalCanopyCoverAndComposition",
     "Compsopogonophyceae": "macroalgalCanopyCoverAndComposition",
-    # Hard coral
+    # ── Hard coral ──
     "Anthozoa": "hardCoralCoverAndComposition",
     "Hexacorallia": "hardCoralCoverAndComposition",
     "Octocorallia": "hardCoralCoverAndComposition",
-    # Invertebrates (catch-all for many marine invertebrate classes)
+    # ── Invertebrates — benthic & other marine invertebrates ──
     "Gastropoda": "invertebrateAbundanceAndDistribution",
     "Bivalvia": "invertebrateAbundanceAndDistribution",
     "Cephalopoda": "invertebrateAbundanceAndDistribution",
@@ -119,12 +225,192 @@ TAXON_CLASS_TO_EOV = {
     "Chromadorea": "invertebrateAbundanceAndDistribution",
     "Monogenea": "invertebrateAbundanceAndDistribution",
     "Hoplonemertea": "invertebrateAbundanceAndDistribution",
-    # Seagrass — Magnoliopsida covers most seagrasses (Zostera, Posidonia, etc.)
+    # New invertebrate additions
+    "Enoplea": "invertebrateAbundanceAndDistribution",         # Nematodes
+    "Caudofoveata": "invertebrateAbundanceAndDistribution",    # Shell-less molluscs
+    "Pilidiophora": "invertebrateAbundanceAndDistribution",    # Nemerteans (ribbon worms)
+    "Palaeonemertea": "invertebrateAbundanceAndDistribution",  # Nemerteans
+    "Leptocardii": "invertebrateAbundanceAndDistribution",     # Lancelets
+    "Enteropneusta": "invertebrateAbundanceAndDistribution",   # Acorn worms
+    "Merostomata": "invertebrateAbundanceAndDistribution",     # Horseshoe crabs
+    "Solenogastres": "invertebrateAbundanceAndDistribution",   # Shell-less molluscs
+    "Homoscleromorpha": "invertebrateAbundanceAndDistribution",# Sponges
+    "Trematoda": "invertebrateAbundanceAndDistribution",       # Flukes
+    # ── Seagrass ──
     "Magnoliopsida": "seagrassCoverAndComposition",
     "Liliopsida": "seagrassCoverAndComposition",
-    # Other
+    # ── Other — organisms not fitting any current GOOS EOV ──
     "Amphibia": "other",
+    "Crocodylia": "other",  # Not covered by any GOOS EOV (sea turtles EOV is turtles only)
 }
+
+
+# Mapping from BODC NERC P01 parameter codes to CIOOS Essential Ocean Variables.
+# measurementTypeID in OBIS eMoF records is typically a URI like
+# http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/ — the 8-char tail
+# is the P01 code we match on. Reference: https://vocab.nerc.ac.uk/collection/P01/current/
+MEASUREMENT_P01_TO_EOV = {
+    # Temperature
+    "TEMPPR01": "subSurfaceTemperature",   # Sea water temperature (CTD)
+    "TEMPST01": "seaSurfaceTemperature",   # Sea surface temperature
+    "TEMPET01": "subSurfaceTemperature",   # Temperature of water by electronic thermometer
+    # Salinity
+    "PSALST01": "seaSurfaceSalinity",      # Practical salinity at surface
+    "PSALPR01": "subSurfaceSalinity",      # Practical salinity (CTD)
+    "PSLTZZ01": "subSurfaceSalinity",      # Practical salinity of water body
+    # Oxygen
+    "DOXYZZXX": "oxygen",
+    "DOXMZZXX": "oxygen",
+    "OXYSZZ01": "oxygen",
+    # Nutrients
+    "NTRAZZXX": "nutrients",               # Nitrate
+    "NTRIZZXX": "nutrients",               # Nitrite
+    "NTRZAAZX": "nutrients",               # Nitrate+nitrite
+    "AMONAAZX": "nutrients",               # Ammonium
+    "PHOSZZXX": "nutrients",               # Phosphate
+    "SLCAAAZX": "nutrients",               # Silicate
+    # Inorganic carbon chemistry
+    "PHXXZZXX": "inorganicCarbon",         # pH
+    "PCO2XXXX": "inorganicCarbon",         # pCO2
+    "ALKYAAZX": "inorganicCarbon",         # Total alkalinity
+    "TCO2AAZX": "inorganicCarbon",         # Dissolved inorganic carbon
+    # Organic carbon
+    "CORGZZZX": "dissolvedOrganicCarbon",
+    "CORGPM01": "particulateMatter",       # Particulate organic carbon
+    # Chlorophyll → ocean colour proxy (no separate chlorophyll EOV)
+    "CPHLZZXX": "oceanColour",
+    "CPHLPR01": "oceanColour",
+    "CPHLMOD2": "oceanColour",             # Chlorophyll fluorescence (modelled)
+    # Turbidity / suspended matter
+    "TURBXXXX": "particulateMatter",
+    "TSEDZZ01": "particulateMatter",
+    # Wind → ocean surface stress proxy
+    "EWSBZZ01": "oceanSurfaceStress",      # Wind speed
+    "EWDAZZ01": "oceanSurfaceStress",      # Wind direction
+    # Sea state — Beaufort wind force is the classic sea-state proxy
+    "WMOCWFBF": "seaState",                # Beaufort wind force
+    "WMOCSSXX": "seaState",                # Beaufort wind force / sea state
+}
+
+
+# Fallback mapping by free-text measurementType, case-insensitive substring match.
+# Used when measurementTypeID is blank (common in older OBIS records). Order
+# matters: more specific keys should precede broader ones. Surface-vs-subsurface
+# for temperature/salinity is handled separately in _map_measurement_pair.
+MEASUREMENT_TEXT_TO_EOV = {
+    # Temperature / salinity — surface vs subsurface disambiguation below
+    "temperature": "subSurfaceTemperature",
+    "salinity": "subSurfaceSalinity",
+    # Oxygen
+    "dissolved oxygen": "oxygen",
+    "oxygen": "oxygen",
+    # Nutrients
+    "nitrate": "nutrients",
+    "nitrite": "nutrients",
+    "ammonium": "nutrients",
+    "phosphate": "nutrients",
+    "silicate": "nutrients",
+    "total nitrogen": "nutrients",
+    "total phosphorus": "nutrients",
+    # Inorganic carbon chemistry
+    "ph": "inorganicCarbon",
+    "pco2": "inorganicCarbon",
+    "alkalinity": "inorganicCarbon",
+    "dic": "inorganicCarbon",
+    # Organic carbon
+    "dissolved organic carbon": "dissolvedOrganicCarbon",
+    "doc": "dissolvedOrganicCarbon",
+    "particulate organic carbon": "particulateMatter",
+    "poc": "particulateMatter",
+    # Chlorophyll / ocean colour
+    "chlorophyll": "oceanColour",
+    # Particulates / turbidity
+    "turbidity": "particulateMatter",
+    "suspended": "particulateMatter",
+    # Currents — default subsurface, surface rule below upgrades "surface current"
+    "current velocity": "subSurfaceCurrents",
+    "current speed": "subSurfaceCurrents",
+    "current direction": "subSurfaceCurrents",
+    "current strength": "subSurfaceCurrents",
+    "tidal current": "surfaceCurrents",
+    # Sea state — must precede wind keys so "Beaufort wind force (sea state)"
+    # matches "beaufort" / "sea state" before falling through to "wind force".
+    "sea state": "seaState",
+    "beaufort": "seaState",
+    "wave height": "seaState",
+    "wave observation": "seaState",
+    "wave exposure": "seaState",
+    # Wind → ocean surface stress
+    "wind speed": "oceanSurfaceStress",
+    "wind direction": "oceanSurfaceStress",
+    "wind force": "oceanSurfaceStress",
+    # Sea ice
+    "sea ice": "seaIce",
+    "ice cover": "seaIce",
+    "ice observation": "seaIce",
+    # Ocean sound — acoustic detection / hydrophone data
+    "hydrophone": "oceanSound",
+    "acoustic detection": "oceanSound",
+    "vocalization": "oceanSound",
+    "call detected": "oceanSound",
+    # Marine debris
+    "marine debris": "marineDebris",
+    "microplastic": "marineDebris",
+    "plastic debris": "marineDebris",
+    # Stable carbon isotopes
+    "delta 13c": "stableCarbonIsotopes",
+    "delta13c": "stableCarbonIsotopes",
+    "d13c": "stableCarbonIsotopes",
+    "δ13c": "stableCarbonIsotopes",
+    # Nitrous oxide
+    "nitrous oxide": "nitrousOxide",
+    "n2o": "nitrousOxide",
+    # Transient tracers
+    "cfc-11": "transientTracers",
+    "cfc-12": "transientTracers",
+    "sf6": "transientTracers",
+    "tritium": "transientTracers",
+}
+
+
+_P01_CODE_RE = re.compile(r"/([A-Z0-9]{8})/?$")
+
+
+def _map_measurement_pair(m_type, m_type_id):
+    """Map one OBIS eMoF (measurementType, measurementTypeID) pair to a CIOOS EOV.
+
+    Priority:
+      1. P01 code extracted from measurementTypeID URI (authoritative).
+      2. Case-insensitive substring match on measurementType free text.
+    Returns None when nothing matches. Temperature/salinity disambiguate
+    between surface and subsurface based on whether 'surface' appears in
+    the free text.
+    """
+    if m_type_id:
+        match = _P01_CODE_RE.search(m_type_id)
+        if match:
+            eov = MEASUREMENT_P01_TO_EOV.get(match.group(1))
+            if eov:
+                return eov
+
+    if not m_type:
+        return None
+
+    text = m_type.lower()
+    has_surface = "surface" in text
+    for key, eov in MEASUREMENT_TEXT_TO_EOV.items():
+        # Word-boundary match — "ph" must not match "chlorophyll", "doc" must
+        # not match "doctor", etc. Multi-word keys like "dissolved oxygen"
+        # also need boundaries on either end of the phrase.
+        if re.search(rf"\b{re.escape(key)}\b", text):
+            if has_surface and eov == "subSurfaceTemperature":
+                return "seaSurfaceTemperature"
+            if has_surface and eov == "subSurfaceSalinity":
+                return "seaSurfaceSalinity"
+            if has_surface and eov == "subSurfaceCurrents":
+                return "surfaceCurrents"
+            return eov
+    return None
 
 
 def add_fr(text):
@@ -269,6 +555,90 @@ def fetch_eovs_from_taxonomy(dataset_id):
             f"Dataset {dataset_id}: no EOVs mapped from taxonomy; falling back to ['other']"
         )
         return ["other"]
+
+    return sorted(eovs)
+
+
+def _has_emof_extension(extensions):
+    """Return True if the dataset declares a MeasurementOrFact extension."""
+    if not extensions:
+        return False
+    for ext in extensions:
+        if not ext:
+            continue
+        if "measurementorfact" in str(ext).lower():
+            return True
+    return False
+
+
+def fetch_eovs_from_measurements(dataset_id, extensions=None, sample_size=100):
+    """Fetch OBIS eMoF measurements for a dataset and map them to CIOOS EOVs.
+
+    Short-circuits when `extensions` is provided and does not list any
+    MeasurementOrFact variant — the majority of OBIS datasets are pure
+    occurrence records, so this keeps the extra HTTP call out of the hot path.
+    Otherwise fetches a bounded sample of occurrences with mof=true and maps
+    the distinct (measurementType, measurementTypeID) pairs via
+    _map_measurement_pair.
+
+    Args:
+        dataset_id: OBIS dataset UUID.
+        extensions: optional list from obis_data['extensions']. Used as a
+            cheap gate to skip datasets without eMoF.
+        sample_size: max occurrences to fetch. Each occurrence can carry
+            several measurements, so 100 is usually enough to cover every
+            distinct measurement type in a CTD-paired dataset.
+
+    Returns:
+        Sorted list of unique CIOOS EOV codes. [] on error, no MoF extension,
+        or nothing mapped.
+    """
+    if not dataset_id:
+        return []
+
+    if extensions is not None and not _has_emof_extension(extensions):
+        logger.debug(
+            f"Dataset {dataset_id}: no MeasurementOrFact extension; skipping eMoF fetch"
+        )
+        return []
+
+    try:
+        response = requests.get(
+            OBIS_OCCURRENCE_URL,
+            params={
+                "datasetid": dataset_id,
+                "mof": "true",
+                "size": sample_size,
+                "fields": "measurementType,measurementTypeID",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (requests.RequestException, ValueError) as e:
+        logger.warning(
+            f"Failed to fetch eMoF measurements for {dataset_id}: {e}"
+        )
+        return []
+
+    pairs = set()
+    for occ in data.get("results", []) or []:
+        for mof in occ.get("mof", []) or []:
+            pairs.add((mof.get("measurementType", ""), mof.get("measurementTypeID", "")))
+
+    eovs = set()
+    unmapped = []
+    for m_type, m_type_id in pairs:
+        eov = _map_measurement_pair(m_type, m_type_id)
+        if eov:
+            eovs.add(eov)
+        elif m_type or m_type_id:
+            unmapped.append((m_type, m_type_id))
+
+    if unmapped:
+        logger.debug(
+            f"Dataset {dataset_id}: unmapped eMoF measurements: {unmapped}"
+        )
 
     return sorted(eovs)
 
@@ -530,9 +900,20 @@ def map_obis_to_cioos(obis_data):
     cioos_data["timeFirstPublished"] = cioos_data[
         "datePublished"
     ]  # Use same as datePublished
-    # Derive EOVs from OBIS taxonomy via the facet API
+    # Derive EOVs from OBIS taxonomy (biology) and eMoF measurements
+    # (physical/biogeochemical). The measurement path short-circuits on
+    # datasets that don't declare a MeasurementOrFact extension.
     dataset_id = obis_data.get("id")
-    cioos_data["eov"] = fetch_eovs_from_taxonomy(dataset_id)
+    extensions = obis_data.get("extensions") or []
+    taxonomy_eovs = fetch_eovs_from_taxonomy(dataset_id)
+    measurement_eovs = fetch_eovs_from_measurements(dataset_id, extensions=extensions)
+
+    merged = set(taxonomy_eovs) | set(measurement_eovs)
+    # When measurement EOVs landed, drop the taxonomy "other" fallback so
+    # we don't emit misleading pairs like ["other", "seaSurfaceTemperature"].
+    if measurement_eovs:
+        merged.discard("other")
+    cioos_data["eov"] = sorted(merged) if merged else ["other"]
     cioos_data["platforms"] = []  # Platform information not available
     cioos_data["projects"] = []  # Project information not available
     cioos_data["region"] = ""  # Geographic region classification

--- a/cioos_metadata_conversion/load_from/obis.py
+++ b/cioos_metadata_conversion/load_from/obis.py
@@ -159,42 +159,34 @@ TAXON_CLASS_TO_EOV = {
     "Nanoarchaeia": "microbeBiomassAndDiversity",
     "Archaeoglobi": "microbeBiomassAndDiversity",
     "Methanococci": "microbeBiomassAndDiversity",
-    # Fungi — marine fungi are microbes per NOAA/NIH/GOOS definitions
-    "Dothideomycetes": "microbeBiomassAndDiversity",
-    "Agaricomycetes": "microbeBiomassAndDiversity",
-    "Sordariomycetes": "microbeBiomassAndDiversity",
-    "Eurotiomycetes": "microbeBiomassAndDiversity",
-    "Tremellomycetes": "microbeBiomassAndDiversity",
-    "Saccharomycetes": "microbeBiomassAndDiversity",
-    "Leotiomycetes": "microbeBiomassAndDiversity",
-    "Microbotryomycetes": "microbeBiomassAndDiversity",
-    "Lecanoromycetes": "microbeBiomassAndDiversity",
-    "Chytridiomycetes": "microbeBiomassAndDiversity",
-    "Cystobasidiomycetes": "microbeBiomassAndDiversity",
-    "Glomeromycetes": "microbeBiomassAndDiversity",
-    "Taphrinomycetes": "microbeBiomassAndDiversity",
-    "Pezizomycetes": "microbeBiomassAndDiversity",
-    "Orbiliomycetes": "microbeBiomassAndDiversity",
-    "Wallemiomycetes": "microbeBiomassAndDiversity",
-    "Ustilaginomycetes": "microbeBiomassAndDiversity",
-    "Agaricostilbomycetes": "microbeBiomassAndDiversity",
-    # Heterotrophic / parasitic protists — eukaryotic microbes
-    "Labyrinthulea": "microbeBiomassAndDiversity",        # Thraustochytrids (decomposers)
-    "Conoidasida": "microbeBiomassAndDiversity",           # Apicomplexa parasites
-    "Perkinsea": "microbeBiomassAndDiversity",             # Parasitic protists (mollusc pathogens)
-    "Kinetoplastea": "microbeBiomassAndDiversity",         # Flagellates (incl. parasites)
-    "Diplonemea": "microbeBiomassAndDiversity",            # Heterotrophic flagellates
-    "Peronosporea": "microbeBiomassAndDiversity",          # Oomycetes
+    # Deliberately *not* mapped to microbeBiomassAndDiversity:
+    #   - Fungal classes (Dothideomycetes, Agaricomycetes, Sordariomycetes,
+    #     Eurotiomycetes, Saccharomycetes, Lecanoromycetes, etc.). OBIS is a
+    #     biodiversity catalogue; these classes include many terrestrial
+    #     fungi (mushrooms, lichens, yeasts) that surface as incidental
+    #     shoreline records and do not indicate a microbe-focused dataset.
+    #   - Host-bound parasites (Conoidasida apicomplexans, Perkinsea mollusc
+    #     pathogens) and ambiguous heterotrophic protists (Labyrinthulea,
+    #     Kinetoplastea, Diplonemea, Peronosporea). GOOS microbe scope is
+    #     free-living marine microbes; these classes appear in occurrence
+    #     data without matching that scope and curators don't tag them.
     # ── Macroalgae ──
     "Phaeophyceae": "macroalgalCanopyCoverAndComposition",
     "Florideophyceae": "macroalgalCanopyCoverAndComposition",
     "Ulvophyceae": "macroalgalCanopyCoverAndComposition",
     "Bangiophyceae": "macroalgalCanopyCoverAndComposition",
     "Compsopogonophyceae": "macroalgalCanopyCoverAndComposition",
-    # ── Hard coral ──
-    "Anthozoa": "hardCoralCoverAndComposition",
-    "Hexacorallia": "hardCoralCoverAndComposition",
-    "Octocorallia": "hardCoralCoverAndComposition",
+    # ── Cnidarian classes → invertebrateAbundanceAndDistribution ──
+    # GOOS hardCoralCoverAndComposition scopes reef-building Scleractinia
+    # (an *order* within Hexacorallia), not classes. Octocorallia (sea pens,
+    # gorgonians, soft corals), Hexacorallia (which also contains anemones
+    # and black corals), and the phylum-level Anthozoa all carry too much
+    # non-hard-coral content to map directly to the cover EOV. CIOOS
+    # curators reflect this — across the audit corpus, 0 datasets were
+    # hand-tagged with hardCoralCoverAndComposition.
+    "Anthozoa": "invertebrateAbundanceAndDistribution",
+    "Hexacorallia": "invertebrateAbundanceAndDistribution",
+    "Octocorallia": "invertebrateAbundanceAndDistribution",
     # ── Invertebrates — benthic & other marine invertebrates ──
     "Gastropoda": "invertebrateAbundanceAndDistribution",
     "Bivalvia": "invertebrateAbundanceAndDistribution",
@@ -284,12 +276,18 @@ MEASUREMENT_P01_TO_EOV = {
     # Turbidity / suspended matter
     "TURBXXXX": "particulateMatter",
     "TSEDZZ01": "particulateMatter",
-    # Wind → ocean surface stress proxy
-    "EWSBZZ01": "oceanSurfaceStress",      # Wind speed
-    "EWDAZZ01": "oceanSurfaceStress",      # Wind direction
+    # Wind P01 codes (EWSBZZ01 wind speed, EWDAZZ01 wind direction) are
+    # deliberately *not* mapped to oceanSurfaceStress. Wind is an input to
+    # the stress product (τ = ρ·Cd·|U|·U), not the EOV itself, and zero
+    # curators tagged oceanSurfaceStress across the audit corpus even on
+    # datasets where the codes could apply. If a platform publishes a
+    # derived stress parameter directly, add that P01 code here.
     # Sea state — Beaufort wind force is the classic sea-state proxy
     "WMOCWFBF": "seaState",                # Beaufort wind force
     "WMOCSSXX": "seaState",                # Beaufort wind force / sea state
+    # Sea surface height — tide-gauge / bottom-pressure surface-elevation codes.
+    "ASLVZZ01": "seaSurfaceHeight",        # Surface elevation, unspecified datum
+    "ASLVTD01": "seaSurfaceHeight",        # Surface elevation by fixed in-situ pressure sensor
 }
 
 
@@ -298,12 +296,26 @@ MEASUREMENT_P01_TO_EOV = {
 # matters: more specific keys should precede broader ones. Surface-vs-subsurface
 # for temperature/salinity is handled separately in _map_measurement_pair.
 MEASUREMENT_TEXT_TO_EOV = {
-    # Temperature / salinity — surface vs subsurface disambiguation below
+    # Temperature / salinity — surface vs subsurface disambiguation below.
+    # French variants included: many DFO Quebec / St. Lawrence OBIS datasets
+    # ship eMoF with French-only or bilingual "label | label" measurementType
+    # strings and no P01 ID. The atmospheric-vs-water-temperature guard in
+    # _map_measurement_pair keeps "Température atmosphérique" from matching.
+    # ASCII snake_case variants (`temp_eau`, `salinite_psu`) appear in some
+    # Comité ZIP Rive Nord de l'Estuaire datasets; underscore is a word
+    # character, so regex word boundaries don't let "temperature"/"salinity"
+    # bleed into these — they need explicit keys.
     "temperature": "subSurfaceTemperature",
+    "température": "subSurfaceTemperature",
+    "temp_eau": "subSurfaceTemperature",
     "salinity": "subSurfaceSalinity",
+    "salinité": "subSurfaceSalinity",
+    "salinite_psu": "subSurfaceSalinity",
     # Oxygen
     "dissolved oxygen": "oxygen",
+    "oxygène dissous": "oxygen",
     "oxygen": "oxygen",
+    "oxygène": "oxygen",
     # Nutrients
     "nitrate": "nutrients",
     "nitrite": "nutrients",
@@ -312,10 +324,14 @@ MEASUREMENT_TEXT_TO_EOV = {
     "silicate": "nutrients",
     "total nitrogen": "nutrients",
     "total phosphorus": "nutrients",
-    # Inorganic carbon chemistry
+    # Inorganic carbon chemistry. A lone pH doesn't emit inorganicCarbon at
+    # the dataset level — see the carbonate-system aggregation in
+    # fetch_eovs_from_measurements. pH still maps here so it contributes
+    # when paired with a "strong" carbonate parameter.
     "ph": "inorganicCarbon",
     "pco2": "inorganicCarbon",
     "alkalinity": "inorganicCarbon",
+    "alcalinité": "inorganicCarbon",
     "dic": "inorganicCarbon",
     # Organic carbon
     "dissolved organic carbon": "dissolvedOrganicCarbon",
@@ -333,17 +349,26 @@ MEASUREMENT_TEXT_TO_EOV = {
     "current direction": "subSurfaceCurrents",
     "current strength": "subSurfaceCurrents",
     "tidal current": "surfaceCurrents",
-    # Sea state — must precede wind keys so "Beaufort wind force (sea state)"
-    # matches "beaufort" / "sea state" before falling through to "wind force".
+    # Sea state — GOOS scope is wave height, period, direction, steepness.
+    # Bare "Beaufort" / "wind" free-text is deliberately *not* mapped: OBIS
+    # eMoF "Beaufort Scale" / "Vent (Beaufort)" / "Wind speed" labels are
+    # usually ancillary wind observations recorded at biological sampling
+    # stations, not wave/stress measurements, and curator tagging is
+    # inconsistent when these are the only signal. The WMOCWFBF / WMOCSSXX
+    # (seaState) and EWSBZZ01 / EWDAZZ01 (oceanSurfaceStress) P01 codes
+    # remain mapped below as authoritative signals.
     "sea state": "seaState",
-    "beaufort": "seaState",
     "wave height": "seaState",
     "wave observation": "seaState",
     "wave exposure": "seaState",
-    # Wind → ocean surface stress
-    "wind speed": "oceanSurfaceStress",
-    "wind direction": "oceanSurfaceStress",
-    "wind force": "oceanSurfaceStress",
+    # Sea surface height — tide-gauge-style numeric height above datum. Phase
+    # labels ("tide level", "tide stage", "stade de la marée") are categorical
+    # ebb/flood markers, not heights, and are deliberately not mapped.
+    "tide height": "seaSurfaceHeight",
+    "hauteur de la marée": "seaSurfaceHeight",  # French, DFO-Quebec
+    "water level": "seaSurfaceHeight",
+    "niveau d'eau": "seaSurfaceHeight",
+    "sea level": "seaSurfaceHeight",
     # Sea ice
     "sea ice": "seaIce",
     "ice cover": "seaIce",
@@ -375,6 +400,41 @@ MEASUREMENT_TEXT_TO_EOV = {
 
 _P01_CODE_RE = re.compile(r"/([A-Z0-9]{8})/?$")
 
+# Air/atmospheric temperature has no CIOOS EOV; these tokens must suppress
+# the "temperature" keys from firing. Without this guard, "Température
+# atmosphérique" matches "température" and emits subSurfaceTemperature.
+_ATMOSPHERIC_RE = re.compile(r"\b(air|atmospheric|atmosph[eé]rique)\b", re.IGNORECASE)
+_TEMPERATURE_EOVS = {"subSurfaceTemperature", "seaSurfaceTemperature"}
+
+# "Per cell" labels are flow-cytometry phytoplankton carbon metrics, not
+# bulk water-column particulate measurements. e.g. the P01 code MAOCCB11
+# ("Organic carbon content per cell") and free-text "Particulate Organic
+# Carbon per cell". These should inform phytoplankton biomass (captured
+# via taxonomy classes) rather than emit particulateMatter.
+_PER_CELL_RE = re.compile(r"\bper\s+cell\b", re.IGNORECASE)
+_PER_CELL_P01 = {"MAOCCB11"}
+
+# Inorganic-carbon EOV requires more than a lone pH to flag at the dataset
+# level. GOOS defines the EOV as the ocean carbonate system (pH, total
+# alkalinity, DIC, pCO2); CIOOS curators in practice only tag it when a
+# non-pH carbonate parameter is present. pH alone is treated as incidental
+# water quality. See fetch_eovs_from_measurements for the aggregation.
+_STRONG_IC_P01 = {"ALKYAAZX", "TCO2AAZX", "PCO2XXXX"}
+_STRONG_IC_TEXT_RE = re.compile(
+    r"\b(alkalinity|alcalinit[eé]|dic|pco2|pco₂)\b", re.IGNORECASE
+)
+
+
+def _is_strong_inorganic_carbon(m_type, m_type_id):
+    """True when an eMoF pair measures a non-pH carbonate parameter."""
+    if m_type_id:
+        match = _P01_CODE_RE.search(m_type_id)
+        if match and match.group(1) in _STRONG_IC_P01:
+            return True
+    if m_type and _STRONG_IC_TEXT_RE.search(m_type):
+        return True
+    return False
+
 
 def _map_measurement_pair(m_type, m_type_id):
     """Map one OBIS eMoF (measurementType, measurementTypeID) pair to a CIOOS EOV.
@@ -384,25 +444,41 @@ def _map_measurement_pair(m_type, m_type_id):
       2. Case-insensitive substring match on measurementType free text.
     Returns None when nothing matches. Temperature/salinity disambiguate
     between surface and subsurface based on whether 'surface' appears in
-    the free text.
+    the free text. Atmospheric/air temperature is suppressed.
     """
+    # Flow-cytometry "per cell" metrics describe phytoplankton carbon
+    # content per individual, not bulk particulates. Suppress before any
+    # mapping attempt so both the P01 and text paths skip these.
+    p01_code = None
     if m_type_id:
         match = _P01_CODE_RE.search(m_type_id)
         if match:
-            eov = MEASUREMENT_P01_TO_EOV.get(match.group(1))
-            if eov:
-                return eov
+            p01_code = match.group(1)
+    is_per_cell = (p01_code in _PER_CELL_P01) or (
+        bool(m_type) and bool(_PER_CELL_RE.search(m_type))
+    )
+    if is_per_cell:
+        return None
+
+    if p01_code:
+        eov = MEASUREMENT_P01_TO_EOV.get(p01_code)
+        if eov:
+            return eov
 
     if not m_type:
         return None
 
     text = m_type.lower()
     has_surface = "surface" in text
+    is_atmospheric = bool(_ATMOSPHERIC_RE.search(text))
     for key, eov in MEASUREMENT_TEXT_TO_EOV.items():
         # Word-boundary match — "ph" must not match "chlorophyll", "doc" must
         # not match "doctor", etc. Multi-word keys like "dissolved oxygen"
         # also need boundaries on either end of the phrase.
         if re.search(rf"\b{re.escape(key)}\b", text):
+            if is_atmospheric and eov in _TEMPERATURE_EOVS:
+                # Air temperature — skip; no matching CIOOS EOV.
+                continue
             if has_surface and eov == "subSurfaceTemperature":
                 return "seaSurfaceTemperature"
             if has_surface and eov == "subSurfaceSalinity":
@@ -506,12 +582,78 @@ OBIS_TO_CIOOS_ROLE = {
 }
 
 
+# "Cover" EOVs describe a habitat-type survey (hard coral reef, seagrass
+# bed, kelp forest), not incidental by-catch. A few Anthozoa records in a
+# 500k-row bottom-trawl dataset shouldn't flag hardCoralCoverAndComposition.
+# We require the contributing class to account for at least this fraction
+# of the dataset's records before emitting a cover EOV.
+COVER_EOVS = {
+    "hardCoralCoverAndComposition",
+    "seagrassCoverAndComposition",
+    "macroalgalCanopyCoverAndComposition",
+}
+COVER_EOV_MIN_FRACTION = 0.05
+
+# "Core" zooplankton classes — planktonic crustaceans, chaetognaths, and
+# pelagic tunicates. These practically never appear as trawl bycatch at
+# meaningful fractions, so their combined presence is a reliable signal
+# that a dataset is actually a zooplankton survey.
+#
+# Excluded deliberately: Scyphozoa, Hydrozoa, Tentaculata, Nuda (jellyfish
+# and ctenophores). These routinely show up at 10–20% in bottom-trawl
+# datasets as gelatinous bycatch without the dataset being a zooplankton
+# study. They still map to zooplanktonBiomassAndDiversity via
+# TAXON_CLASS_TO_EOV — but only count toward the EOV when paired with
+# a core class that clears ZOO_MIN_CORE_FRACTION.
+CORE_ZOOPLANKTON_CLASSES = {
+    "Copepoda",
+    "Hexanauplia",
+    "Maxillopoda",
+    "Branchiopoda",
+    "Ostracoda",
+    "Sagittoidea",
+    "Appendicularia",
+    "Thaliacea",
+}
+ZOO_MIN_CORE_FRACTION = 0.05
+
+# "Benthic indicator" classes — unambiguous markers of a benthic
+# invertebrate community (echinoderms, sponges, ascidians, barnacles,
+# bryozoans, sessile cnidarians, chitons, scaphopods). When a dataset is
+# already emitting zooplanktonBiomassAndDiversity, the presence of one of
+# these classes is what distinguishes "zooplankton net that also sampled
+# benthic epifauna" from "zooplankton net with larval inverts in it."
+# Without any benthic indicator, Malacostraca / Gastropoda / Polychaeta /
+# Bivalvia / Cephalopoda are more likely planktonic (krill, mysids,
+# pteropods, larval polychaetes, pelagic squid) than benthic bycatch.
+BENTHIC_INDICATOR_CLASSES = {
+    "Asteroidea",
+    "Ophiuroidea",
+    "Holothuroidea",
+    "Crinoidea",
+    "Echinoidea",
+    "Demospongiae",
+    "Calcarea",
+    "Hexactinellida",
+    "Ascidiacea",
+    "Thecostraca",
+    "Polyplacophora",
+    "Scaphopoda",
+    "Gymnolaemata",
+    "Stenolaemata",
+    "Anthozoa",
+    "Hexacorallia",
+    "Octocorallia",
+}
+
+
 def fetch_eovs_from_taxonomy(dataset_id):
     """Fetch taxonomic classes for an OBIS dataset and map them to CIOOS EOVs.
 
     Calls the OBIS facet API to get class-level taxonomy, then maps each class
     to a CIOOS Essential Ocean Variable using TAXON_CLASS_TO_EOV.
-    Returns a deduplicated list of EOV codes.
+    Returns a deduplicated list of EOV codes. Cover-type EOVs are subject to
+    a record-fraction threshold to suppress by-catch false positives.
     """
     if not dataset_id:
         return []
@@ -533,20 +675,77 @@ def fetch_eovs_from_taxonomy(dataset_id):
         logger.info(f"No taxonomic classes found for dataset {dataset_id}")
         return []
 
+    total_records = sum(entry.get("records", 0) or 0 for entry in classes)
     eovs = set()
     unmapped = []
     for entry in classes:
         taxon_class = entry.get("key", "")
         eov = TAXON_CLASS_TO_EOV.get(taxon_class)
-        if eov:
-            eovs.add(eov)
-        else:
+        if not eov:
             unmapped.append(taxon_class)
+            continue
+        records = entry.get("records", 0) or 0
+        if (
+            eov in COVER_EOVS
+            and total_records > 0
+            and records / total_records < COVER_EOV_MIN_FRACTION
+        ):
+            logger.debug(
+                f"Dataset {dataset_id}: class {taxon_class} "
+                f"({records}/{total_records} = {records / total_records:.2%}) "
+                f"below cover-EOV threshold {COVER_EOV_MIN_FRACTION:.0%}; "
+                f"skipping {eov}"
+            )
+            continue
+        eovs.add(eov)
 
     if unmapped:
         logger.info(
             f"Dataset {dataset_id}: unmapped taxonomic classes: {unmapped}"
         )
+
+    # Zooplankton gate: require core planktonic classes (Copepoda, Ostracoda,
+    # Sagittoidea, etc.) to clear ZOO_MIN_CORE_FRACTION. Gelatinous bycatch
+    # alone (Scyphozoa, Hydrozoa) is not enough.
+    if "zooplanktonBiomassAndDiversity" in eovs and total_records > 0:
+        core_records = sum(
+            (entry.get("records", 0) or 0)
+            for entry in classes
+            if entry.get("key") in CORE_ZOOPLANKTON_CLASSES
+        )
+        if core_records / total_records < ZOO_MIN_CORE_FRACTION:
+            logger.debug(
+                f"Dataset {dataset_id}: core zooplankton classes "
+                f"({core_records}/{total_records} = "
+                f"{core_records / total_records:.2%}) below threshold "
+                f"{ZOO_MIN_CORE_FRACTION:.0%}; dropping "
+                f"zooplanktonBiomassAndDiversity"
+            )
+            eovs.discard("zooplanktonBiomassAndDiversity")
+
+    # Invertebrate gate (plankton-net refinement): if zooplankton is emitted,
+    # require a benthic-indicator class for invertebrate to also emit. In a
+    # plankton net, Malacostraca/Gastropoda/Polychaeta/Bivalvia/Cephalopoda
+    # are usually larval or pelagic forms already captured under zooplankton,
+    # not a separate benthic community. A visible benthic-sessile class
+    # (echinoderm, sponge, ascidian, barnacle, etc.) is what lifts the
+    # dataset into "also sampled epifauna" territory.
+    if (
+        "zooplanktonBiomassAndDiversity" in eovs
+        and "invertebrateAbundanceAndDistribution" in eovs
+    ):
+        has_benthic = any(
+            entry.get("key") in BENTHIC_INDICATOR_CLASSES
+            and (entry.get("records", 0) or 0) > 0
+            for entry in classes
+        )
+        if not has_benthic:
+            logger.debug(
+                f"Dataset {dataset_id}: zooplankton emitted but no benthic "
+                f"indicator class present; dropping "
+                f"invertebrateAbundanceAndDistribution"
+            )
+            eovs.discard("invertebrateAbundanceAndDistribution")
 
     # CIOOS requires at least one EOV; if we can't map any taxonomy classes
     # (or if a dataset only contains odd/terrestrial classes), fall back to "other".
@@ -628,12 +827,24 @@ def fetch_eovs_from_measurements(dataset_id, extensions=None, sample_size=100):
 
     eovs = set()
     unmapped = []
+    has_strong_inorganic_carbon = False
     for m_type, m_type_id in pairs:
         eov = _map_measurement_pair(m_type, m_type_id)
         if eov:
             eovs.add(eov)
         elif m_type or m_type_id:
             unmapped.append((m_type, m_type_id))
+        if _is_strong_inorganic_carbon(m_type, m_type_id):
+            has_strong_inorganic_carbon = True
+
+    # Drop inorganicCarbon when only pH was measured — CIOOS curator
+    # convention treats lone pH as water quality, not carbonate chemistry.
+    if "inorganicCarbon" in eovs and not has_strong_inorganic_carbon:
+        eovs.discard("inorganicCarbon")
+        logger.debug(
+            f"Dataset {dataset_id}: dropping inorganicCarbon (pH-only, no "
+            f"alkalinity/DIC/pCO2)"
+        )
 
     if unmapped:
         logger.debug(
@@ -901,8 +1112,11 @@ def map_obis_to_cioos(obis_data):
         "datePublished"
     ]  # Use same as datePublished
     # Derive EOVs from OBIS taxonomy (biology) and eMoF measurements
-    # (physical/biogeochemical). The measurement path short-circuits on
-    # datasets that don't declare a MeasurementOrFact extension.
+    # (physical/biogeochemical). Both paths use controlled-vocabulary
+    # signals only — taxonomy class names and eMoF P01 codes / parameter
+    # labels. Abstract / title / keyword NLP is intentionally out of
+    # scope here; a separate AI-backed tool handles abstract-based EOV
+    # inference, and mixing the two produces inconsistent tagging.
     dataset_id = obis_data.get("id")
     extensions = obis_data.get("extensions") or []
     taxonomy_eovs = fetch_eovs_from_taxonomy(dataset_id)

--- a/cioos_metadata_conversion/load_from/obis.py
+++ b/cioos_metadata_conversion/load_from/obis.py
@@ -1,4 +1,6 @@
+import json
 import re
+from pathlib import Path
 
 import requests
 from loguru import logger
@@ -854,6 +856,208 @@ def fetch_eovs_from_measurements(dataset_id, extensions=None, sample_size=100):
     return sorted(eovs)
 
 
+# ── Platform inference ──────────────────────────────────────────────────────
+# OBIS exposes no structured platform field; DwC samplingProtocol (free text
+# on occurrence records) is the only reliable signal. We sample occurrences,
+# match samplingProtocol against the controlled keyword table below, and emit
+# values from the CIOOS form vocabulary (cioos_metadata_conversion/resources/
+# platforms.json — mirrors cioos-siooc/metadata-entry-form/src/platforms.json).
+# Conservative on purpose: when nothing matches we emit no platform and the
+# loader sets noPlatform=True. Mixing free-text NLP with controlled-vocab
+# signals is the same trap the EOV mapping deliberately avoids (see line ~1117).
+
+_PLATFORM_RESOURCE_PATH = (
+    Path(__file__).parent.parent / "resources" / "platforms.json"
+)
+
+
+def _load_platform_vocab():
+    """Return the set of valid CIOOS platform label_en strings."""
+    with open(_PLATFORM_RESOURCE_PATH, encoding="utf-8") as f:
+        return {entry["label_en"] for entry in json.load(f)}
+
+
+VALID_PLATFORM_LABELS = _load_platform_vocab()
+
+
+# Ordered keyword table. Each entry is (pattern, label_en). Patterns are
+# case-insensitive substring/word matches over samplingProtocol text. Order
+# does not matter for correctness — overlap is resolved post-match via
+# _PLATFORM_SPECIFICITY below — but specific patterns are listed first to
+# make the intent readable.
+_PLATFORM_KEYWORD_TABLE = [
+    # Moorings / floats / buoys
+    (r"\b(?:subsurface|sub-surface|bottom)\s+mooring\b", "subsurface mooring"),
+    (
+        r"\b(?:moored\s+(?:surface\s+)?buoy|surface\s+buoy|wave\s+buoy)\b",
+        "moored surface buoy",
+    ),
+    (r"\b(?:mooring|moored)\b", "mooring"),
+    (
+        r"\b(?:argo\s+float|profiling\s+float)\b",
+        "drifting subsurface profiling float",
+    ),
+    (
+        r"\b(?:drifting\s+buoy|drifter|argos\s+drifter)\b",
+        "drifting surface float",
+    ),
+    # Gliders
+    (r"\bsurface\s+glider", "surface gliders"),
+    (r"\bglider\b", "sub-surface gliders"),
+    # Submersibles
+    (
+        r"\b(?:auv|autonomous\s+underwater\s+vehicle)\b",
+        "autonomous underwater vehicle",
+    ),
+    (
+        r"\b(?:rov|remotely\s+operated\s+vehicle)\b",
+        "propelled unmanned submersible",
+    ),
+    # Vessels — specific first, generic last; specificity table strips
+    # the generic "ship" hit when a more-specific vessel label is present.
+    (
+        r"\b(?:research\s+vessel|r/v|research\s+cruise|ccgs|expedition)\b",
+        "research vessel",
+    ),
+    (r"\b(?:fishing\s+vessel|trawler|seiner)\b", "fishing vessel"),
+    (r"\b(?:vessel|ship|boat)\b", "ship"),
+    # Divers / humans in water
+    (r"\b(?:diver|scuba|snorkel|free\s+dive)\b", "diver"),
+    # Aircraft / aerial
+    (r"\b(?:drone|uav|unmanned\s+aerial)\b", "unmanned aerial vehicle"),
+    (r"\bhelicopter\b", "helicopter"),
+    (r"\b(?:aircraft|airplane|aeroplane|aerial)\b", "aeroplane"),
+    # Remote sensing
+    (r"\bsatellite\b", "satellite"),
+    # Land / coastal / seafloor
+    (
+        r"\b(?:shore|beach|intertidal|marsh|tidepool|tide\s+pool|shoreline)\b",
+        "beach/intertidal zone structure",
+    ),
+    (r"\b(?:onshore|terrestrial)\b", "land/onshore structure"),
+    (
+        r"\b(?:seafloor|seabed|benthic\s+lander|lander)\b",
+        "fixed benthic node",
+    ),
+    (
+        r"\b(?:offshore\s+platform|oil\s+platform|wind\s+farm|drilling\s+rig)\b",
+        "offshore structure",
+    ),
+    (r"\b(?:coastal\s+station|pier|wharf|jetty)\b", "coastal structure"),
+    (r"\b(?:river\s+station|stream\s+gauge)\b", "river station"),
+]
+
+_PLATFORM_KEYWORDS_COMPILED = [
+    (re.compile(pat, re.IGNORECASE), label)
+    for pat, label in _PLATFORM_KEYWORD_TABLE
+]
+
+# When the LHS label is matched, drop any RHS labels from the result set.
+# Lets generic patterns like \bvessel\b stay in the table without producing
+# duplicate hits when a more specific phrase (e.g. "research vessel") also
+# matched. Same trick for moorings, drifters, aircraft.
+_PLATFORM_SPECIFICITY = {
+    "research vessel": {"ship"},
+    "fishing vessel": {"ship"},
+    "moored surface buoy": {"mooring"},
+    "subsurface mooring": {"mooring"},
+    "drifting subsurface profiling float": {"drifting surface float"},
+    "surface gliders": {"sub-surface gliders"},
+    "unmanned aerial vehicle": {"aeroplane"},
+    "helicopter": {"aeroplane"},
+}
+
+
+def _match_platform_keywords(text):
+    """Return CIOOS platform label_en values matched in text.
+
+    Case-insensitive. Deduplicated. Applies the specificity overrides so
+    generic labels are dropped when a more specific label also hit.
+    """
+    if not text:
+        return []
+    hits = []
+    for regex, label in _PLATFORM_KEYWORDS_COMPILED:
+        if label in hits:
+            continue
+        if regex.search(text):
+            hits.append(label)
+
+    drop = set()
+    for specific, generics in _PLATFORM_SPECIFICITY.items():
+        if specific in hits:
+            drop.update(generics)
+
+    return [h for h in hits if h not in drop]
+
+
+def fetch_platforms_from_obis(dataset_id, sample_size=100):
+    """Sample OBIS occurrences and infer CIOOS platform types.
+
+    Reads samplingProtocol from a bounded slice of /v3/occurrence records,
+    matches it against _PLATFORM_KEYWORD_TABLE, and returns a list of
+    {"id", "type", "description"} dicts whose "type" is a label_en from
+    the bundled CIOOS platform vocabulary. Returns [] when nothing was
+    sampled, no samplingProtocol carried recognisable keywords, or the
+    API call failed — callers should then set noPlatform=True.
+
+    Args:
+        dataset_id: OBIS dataset UUID.
+        sample_size: max occurrences to fetch. 100 is usually enough to
+            cover the distinct samplingProtocol strings used in a dataset.
+    """
+    if not dataset_id:
+        return []
+
+    try:
+        response = requests.get(
+            OBIS_OCCURRENCE_URL,
+            params={
+                "datasetid": dataset_id,
+                "size": sample_size,
+                "fields": "samplingProtocol,basisOfRecord",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (requests.RequestException, ValueError) as e:
+        logger.warning(
+            f"Failed to fetch occurrences for platform inference {dataset_id}: {e}"
+        )
+        return []
+
+    protocols = set()
+    for occ in data.get("results", []) or []:
+        proto = occ.get("samplingProtocol")
+        if proto:
+            protocols.add(proto)
+
+    matched_labels = []
+    for proto in protocols:
+        for label in _match_platform_keywords(proto):
+            if label in matched_labels:
+                continue
+            if label not in VALID_PLATFORM_LABELS:
+                # Belt-and-braces: the keyword table is authored against the
+                # vendored vocab, but flag drift instead of emitting garbage.
+                logger.warning(
+                    f"Platform label '{label}' is not in the CIOOS "
+                    f"vocabulary; skipping (dataset {dataset_id})"
+                )
+                continue
+            matched_labels.append(label)
+
+    return [
+        {
+            "id": f"obis-platform-{i + 1}",
+            "type": label,
+            "description": {"en": "", "fr": ""},
+        }
+        for i, label in enumerate(matched_labels)
+    ]
+
+
 def map_obis_role_to_cioos(obis_role):
     """Map an OBIS EML role/type to a valid CIOOS ISO 19115 role code.
 
@@ -1095,7 +1299,7 @@ def map_obis_to_cioos(obis_data):
     cioos_data["edition"] = ""
     cioos_data["filename"] = ""
     cioos_data["identifier"] = ""
-    cioos_data["noPlatform"] = ""
+    # noPlatform is set after platform inference below.
     cioos_data["progress"] = ""
     cioos_data["recordID"] = ""
     cioos_data["status"] = ""
@@ -1128,7 +1332,15 @@ def map_obis_to_cioos(obis_data):
     if measurement_eovs:
         merged.discard("other")
     cioos_data["eov"] = sorted(merged) if merged else ["other"]
-    cioos_data["platforms"] = []  # Platform information not available
+
+    # Infer platforms from DwC samplingProtocol on occurrence records. OBIS
+    # has no structured platform field, so a no-hit result is the common
+    # case; flip noPlatform=True so firebase_to_cioos.py:318 cleanly skips
+    # the platform path and the XML omits the section.
+    platforms = fetch_platforms_from_obis(dataset_id)
+    cioos_data["platforms"] = platforms
+    cioos_data["noPlatform"] = not platforms
+
     cioos_data["projects"] = []  # Project information not available
     cioos_data["region"] = ""  # Geographic region classification
 

--- a/cioos_metadata_conversion/load_from/obis.py
+++ b/cioos_metadata_conversion/load_from/obis.py
@@ -363,7 +363,11 @@ def convert_contacts(obis_contacts):
 def map_obis_to_cioos(obis_data):
     cioos_data = {}
     cioos_data["abstract"] = add_fr(obis_data.get("abstract", ""))
-    cioos_data["datasetIdentifier"] = obis_data.get("id")
+    # Only set datasetIdentifier when the dataset has a real DOI.
+    # The metadata-xml template emits a bare cit:identifier (no mcc:authority)
+    # and the CKAN harvester defaults unqualified identifiers to doi.org,
+    # producing broken links like doi.org/<UUID> for datasets without DOIs.
+    cioos_data["datasetIdentifier"] = obis_data.get("doi", "") or ""
     cioos_data["title"] = add_fr(obis_data.get("title", ""))
     cioos_data["license"] = obis_data.get("intellectualrights", "")
     cioos_data["category"] = "dataset"
@@ -378,7 +382,9 @@ def map_obis_to_cioos(obis_data):
             elif isinstance(keyword, str):
                 keywords.append(keyword)
 
-    cioos_data["keywords"] = {"en": keywords, "fr": []}
+    # OBIS only provides English keywords. Use them as French placeholders
+    # since many are scientific terms or proper nouns that don't change.
+    cioos_data["keywords"] = {"en": keywords, "fr": keywords}
 
     # Associated resources
     associated_resources = []
@@ -435,7 +441,26 @@ def map_obis_to_cioos(obis_data):
     cioos_data["associated_resources"] = associated_resources
     cioos_data["contacts"] = convert_contacts(obis_data.get("contacts"))
 
-    created_date = obis_data.get("created")
+    # The metadata-xml template only emits mdb:contact (required by ISO 19115-3)
+    # for contacts with the "custodian" role.  When the OBIS metadataProvider
+    # entry has no name/org it gets dropped by convert_contacts(), leaving no
+    # custodian.  Promote the first available contact so the XML stays valid.
+    has_custodian = any(
+        "custodian" in c.get("role", []) for c in cioos_data["contacts"]
+    )
+    if not has_custodian and cioos_data["contacts"]:
+        cioos_data["contacts"][0]["role"].append("custodian")
+        logger.info(
+            "No custodian contact found; promoted first contact to custodian"
+        )
+
+    # Dates — the metadata-xml template requires metadata.dates to survive
+    # scrub_dict (which strips empty values).  When created or published are
+    # missing we fall back to updated so at least one date is always present.
+    updated_date = obis_data.get("updated", "")
+    updated_clean = updated_date.split(".")[0] + "Z" if updated_date else ""
+
+    created_date = obis_data.get("created") or updated_date
     if created_date:
         cioos_data["created"] = created_date.split(".")[0] + "Z"
     else:
@@ -446,18 +471,14 @@ def map_obis_to_cioos(obis_data):
     cioos_data["dateEnd"] = ""
 
     # Dataset publication
-    published_date = obis_data.get("published", "")
+    published_date = obis_data.get("published", "") or updated_date
     if published_date:
         cioos_data["datePublished"] = published_date.split(".")[0] + "Z"
     else:
         cioos_data["datePublished"] = ""
 
     # Last revision / update
-    updated_date = obis_data.get("updated", "")
-    if updated_date:
-        cioos_data["dateRevised"] = updated_date.split(".")[0] + "Z"
-    else:
-        cioos_data["dateRevised"] = ""
+    cioos_data["dateRevised"] = updated_clean
 
     # Spatial extent
     cioos_data["map"] = parse_extent_to_map(obis_data.get("extent"))

--- a/cioos_metadata_conversion/load_from/obis.py
+++ b/cioos_metadata_conversion/load_from/obis.py
@@ -1,0 +1,299 @@
+import requests
+from loguru import logger
+
+OBIS_API_BASE = "https://api.obis.org/v3/dataset"
+
+
+def add_fr(text):
+    outtext = {}
+    outtext["en"] = text
+    outtext["fr"] = "Traduction française actuellement indisponible"
+    outtext["translations"] = {
+        "fr": {
+            "message": "text translations coming soon / Traductions de textes à venir",
+            "verified": False,
+        }
+    }
+    return outtext
+
+
+def parse_extent_to_map(extent_wkt):
+    """
+    Parse OBIS extent POLYGON to CIOOS map format.
+    Returns dict with north, south, east, west, polygon, description.
+    """
+    if not extent_wkt:
+        return {}
+
+    try:
+        # Extract coordinates from POLYGON((lon lat, lon lat, ...))
+        # Handle potential variations in WKT format if necessary,
+        # but this simple split assumes POLYGON((...)) standard format
+        coords_str = extent_wkt.split("POLYGON((")[1].split("))")[0]
+        coord_pairs = coords_str.split(",")
+
+        lons = []
+        lats = []
+
+        polygon = ""
+        for pair in coord_pairs:
+            pair = pair.strip()
+            if not pair:
+                continue
+            parts = pair.split()
+            if len(parts) >= 2:
+                lon = float(parts[0])
+                lat = float(parts[1])
+                lons.append(lon)
+                lats.append(lat)
+                polygon += f"{lon},{lat} "
+
+        if not lons or not lats:
+            return {
+                "polygon": extent_wkt,
+                "description": {"en": ""},
+            }
+
+        return {
+            "north": str(max(lats)),
+            "south": str(min(lats)),
+            "east": str(max(lons)),
+            "west": str(min(lons)),
+            "polygon": polygon.strip(),
+            "description": {"en": "Spatial extent from OBIS"},
+        }
+    except (IndexError, ValueError) as e:
+        logger.warning(f"Failed to parse extent WKT: {extent_wkt}. Error: {e}")
+        # If parsing fails, return empty map but keep original polygon if possible
+        return {
+            "polygon": extent_wkt,  # Keep the original even if we can't parse it
+            "description": {"en": ""},
+        }
+
+
+def convert_contacts(obis_contacts):
+    cioos_contacts = []
+    if not obis_contacts:
+        return cioos_contacts
+
+    for contact in obis_contacts:
+        given_name = contact.get("givenname", "")
+        last_name = contact.get("surname", "")
+
+        # Build full name
+        full_name = ""
+        if given_name and last_name:
+            full_name = f"{given_name} {last_name}"
+        elif given_name:
+            full_name = given_name
+        elif last_name:
+            full_name = last_name
+
+        cioos_contact = {
+            "givenNames": given_name,
+            "lastName": last_name,
+            "indName": full_name,
+            "indOrcid": "",
+            "inCitation": True,  # Default to true for creators/authors
+            "role": [contact.get("type", "")],  # role is an array in CIOOS
+            "orgName": contact.get("organization", ""),
+            "orgAddress": "",
+            "orgCity": "",
+            "orgCountry": "",
+            "orgRor": "",
+            "orgURL": contact.get("url", ""),
+        }
+
+        # For contacts with email, add it with different field name
+        if contact.get("email"):
+            cioos_contact["indEmail"] = contact.get("email")
+
+        # Add position if available
+        if contact.get("position"):
+            cioos_contact["position"] = contact.get("position")
+
+        cioos_contacts.append(cioos_contact)
+
+    return cioos_contacts
+
+
+def map_obis_to_cioos(obis_data):
+    cioos_data = {}
+    cioos_data["abstract"] = add_fr(obis_data.get("abstract", ""))
+    cioos_data["datasetIdentifier"] = obis_data.get("id")
+    cioos_data["title"] = add_fr(obis_data.get("title", ""))
+    cioos_data["license"] = obis_data.get("intellectualrights", "")
+    cioos_data["category"] = "dataset"
+    cioos_data["comment"] = ""
+
+    # Keywords
+    keywords = []
+    if obis_data.get("keywords"):
+        for keyword in obis_data["keywords"]:
+            if isinstance(keyword, dict):
+                keywords.append(keyword.get("keyword"))
+            elif isinstance(keyword, str):
+                keywords.append(keyword)
+
+    cioos_data["keywords"] = {"en": keywords, "fr": []}
+
+    # Associated resources
+    associated_resources = []
+
+    # Primary dataset URL
+    if obis_data.get("url"):
+        associated_resources.append(
+            {
+                "association_type": "IsIdenticalTo",
+                "association_type_iso": "crossReference",
+                "authority": "URL",
+                "code": obis_data["url"],
+                "title": "Primary dataset URL",
+            }
+        )
+
+    # Archive URL
+    if obis_data.get("archive") and obis_data["archive"] != obis_data.get("url"):
+        associated_resources.append(
+            {
+                "association_type": "IsIdenticalTo",
+                "association_type_iso": "crossReference",
+                "authority": "URL",
+                "code": obis_data["archive"],
+                "title": "Dataset archive",
+            }
+        )
+
+    # Metadata feed
+    if obis_data.get("feed") and obis_data["feed"].get("url"):
+        associated_resources.append(
+            {
+                "association_type": "IsIdenticalTo",
+                "association_type_iso": "crossReference",
+                "authority": "URL",
+                "code": obis_data["feed"]["url"],
+                "title": "Metadata feed source",
+            }
+        )
+
+    # Tags (e.g., vocabulary terms)
+    if obis_data.get("tags"):
+        for tag in obis_data["tags"]:
+            associated_resources.append(
+                {
+                    "association_type": "IsDescribedBy",
+                    "association_type_iso": "crossReference",
+                    "authority": "URL",
+                    "code": tag,
+                    "title": "OBIS Dataset Type vocabulary term",
+                }
+            )
+
+    cioos_data["associated_resources"] = associated_resources
+    cioos_data["contacts"] = convert_contacts(obis_data.get("contacts"))
+
+    created_date = obis_data.get("created")
+    if created_date:
+        cioos_data["created"] = created_date.split(".")[0] + "Z"
+    else:
+        cioos_data["created"] = ""
+
+    # Temporal extent of data collection (not available in OBIS metadata)
+    cioos_data["dateStart"] = ""
+    cioos_data["dateEnd"] = ""
+
+    # Dataset publication
+    published_date = obis_data.get("published", "")
+    if published_date:
+        cioos_data["datePublished"] = published_date.split(".")[0] + "Z"
+    else:
+        cioos_data["datePublished"] = ""
+
+    # Last revision / update
+    updated_date = obis_data.get("updated", "")
+    if updated_date:
+        cioos_data["dateRevised"] = updated_date.split(".")[0] + "Z"
+    else:
+        cioos_data["dateRevised"] = ""
+
+    # Spatial extent
+    cioos_data["map"] = parse_extent_to_map(obis_data.get("extent"))
+
+    # Distribution - data access information
+    distribution = []
+    if obis_data.get("archive"):
+        distribution.append(
+            {
+                "name": add_fr("Darwin Core Archive"),
+                "url": obis_data["archive"],
+                "description": add_fr(
+                    "Download the complete Darwin Core Archive dataset"
+                ),
+            }
+        )
+    if obis_data.get("url") and obis_data.get("url") != obis_data.get("archive"):
+        distribution.append(
+            {
+                "name": add_fr("IPT Resource Page"),
+                "url": obis_data["url"],
+                "description": add_fr(
+                    "View dataset metadata and access options via the Integrated Publishing Toolkit"
+                ),
+            }
+        )
+    cioos_data["distribution"] = distribution
+
+    # Constant fields - all OBIS records are datasets
+    cioos_data["metadataScope"] = "Dataset"
+    cioos_data["resourceType"] = "Dataset"
+    cioos_data["doiCreationStatus"] = ""
+    cioos_data["edition"] = ""
+    cioos_data["filename"] = ""
+    cioos_data["identifier"] = ""
+    cioos_data["noPlatform"] = ""
+    cioos_data["progress"] = ""
+    cioos_data["recordID"] = ""
+    cioos_data["status"] = ""
+    cioos_data["userID"] = ""
+    cioos_data["lastEditedBy"] = {"displayName": "", "email": ""}
+    cioos_data["language"] = "en"
+
+    # Additional CIOOS fields not available in OBIS
+    cioos_data["limitations"] = add_fr("")  # Usage limitations/constraints
+    cioos_data["noTaxa"] = True  # OBIS metadata doesn't include taxon lists
+    cioos_data["noVerticalExtent"] = True  # Vertical extent not in OBIS metadata
+    cioos_data["verticalExtentDirection"] = ""  # e.g., "depthPositive"
+    cioos_data["timeFirstPublished"] = cioos_data[
+        "datePublished"
+    ]  # Use same as datePublished
+    cioos_data["eov"] = []  # Essential Ocean Variables - can't map from OBIS
+    cioos_data["platforms"] = []  # Platform information not available
+    cioos_data["projects"] = []  # Project information not available
+    cioos_data["region"] = ""  # Geographic region classification
+
+    return cioos_data
+
+
+def retrieve_obis_metadata(dataset_id: str):
+    """
+    Retrieve metadata for an OBIS dataset by ID.
+    """
+    url = f"{OBIS_API_BASE}/{dataset_id}"
+    logger.info(f"Retrieving OBIS metadata from: {url}")
+
+    response = requests.get(url)
+    response.raise_for_status()
+
+    obis_data = response.json()
+
+    # OBIS API returns a dict with "results" list
+    if "results" in obis_data:
+        if not obis_data["results"]:
+            raise ValueError(f"No OBIS dataset found with ID: {dataset_id}")
+        obis_data = obis_data["results"][0]
+    elif isinstance(obis_data, list):
+        if not obis_data:
+            raise ValueError(f"No OBIS dataset found with ID: {dataset_id}")
+        obis_data = obis_data[0]
+
+    return map_obis_to_cioos(obis_data)

--- a/cioos_metadata_conversion/load_from/obis.py
+++ b/cioos_metadata_conversion/load_from/obis.py
@@ -71,6 +71,66 @@ def parse_extent_to_map(extent_wkt):
         }
 
 
+# Valid CIOOS/ISO 19115 role codes (from cioos-siooc_schema.json)
+CIOOS_ROLE_CODES = {
+    "author", "custodian", "distributor", "originator", "owner",
+    "pointOfContact", "principalInvestigator", "processor", "publisher",
+    "resourceProvider", "user", "sponsor", "coAuthor", "collaborator",
+    "editor", "mediator", "rightsHolder", "contributor", "funder",
+    "stakeholder",
+}
+
+# Mapping from OBIS EML construct types to CIOOS role codes.
+# OBIS uses EML element names (creator, contact, metadataProvider, etc.)
+# as the contact "type" field. These don't exist in the ISO role codelist
+# that CIOOS uses, so we map them to the closest CIOOS equivalent.
+# See: https://manual.obis.org/eml.html
+# See: https://github.com/cioos-siooc/metadata-xml
+OBIS_TO_CIOOS_ROLE = {
+    "creator": "author",
+    "contact": "pointOfContact",
+    "metadataProvider": "custodian",
+    "metadataprovider": "custodian",
+    "associatedParty": "contributor",
+    "associatedparty": "contributor",
+    "personnel": "contributor",
+}
+
+
+def map_obis_role_to_cioos(obis_role):
+    """Map an OBIS EML role/type to a valid CIOOS ISO 19115 role code.
+
+    Checks in order:
+    1. If the role is already a valid CIOOS role code, use it as-is.
+    2. If it matches a known OBIS EML construct, map it.
+    3. Otherwise fall back to 'contributor'.
+    """
+    if not obis_role:
+        return "contributor"
+
+    # Already a valid CIOOS role code (e.g. from associatedParty/role)
+    if obis_role in CIOOS_ROLE_CODES:
+        return obis_role
+
+    # Known OBIS EML construct mapping
+    mapped = OBIS_TO_CIOOS_ROLE.get(obis_role)
+    if mapped:
+        return mapped
+
+    # Case-insensitive fallback check
+    lower = obis_role.lower()
+    for code in CIOOS_ROLE_CODES:
+        if lower == code.lower():
+            return code
+
+    mapped = OBIS_TO_CIOOS_ROLE.get(lower)
+    if mapped:
+        return mapped
+
+    logger.warning(f"Unknown OBIS role '{obis_role}', falling back to 'contributor'")
+    return "contributor"
+
+
 def convert_contacts(obis_contacts):
     cioos_contacts = []
     if not obis_contacts:
@@ -95,7 +155,7 @@ def convert_contacts(obis_contacts):
             "indName": full_name,
             "indOrcid": "",
             "inCitation": True,  # Default to true for creators/authors
-            "role": [contact.get("type", "")],  # role is an array in CIOOS
+            "role": [map_obis_role_to_cioos(contact.get("type", ""))],
             "orgName": contact.get("organization", ""),
             "orgAddress": "",
             "orgCity": "",

--- a/cioos_metadata_conversion/load_from/obis.py
+++ b/cioos_metadata_conversion/load_from/obis.py
@@ -2,6 +2,129 @@ import requests
 from loguru import logger
 
 OBIS_API_BASE = "https://api.obis.org/v3/dataset"
+OBIS_FACET_URL = "https://api.obis.org/v3/facet"
+
+# Mapping from OBIS taxonomic class names to CIOOS Essential Ocean Variables.
+# Built from the OBIS /v3/facet?facets=class endpoint values and the CIOOS
+# EOV choices in cioos-siooc_schema.json.
+TAXON_CLASS_TO_EOV = {
+    # Fish — fishAbundanceAndDistribution
+    "Actinopterygii": "fishAbundanceAndDistribution",
+    "Teleostei": "fishAbundanceAndDistribution",
+    "Elasmobranchii": "fishAbundanceAndDistribution",
+    "Chondrichthyes": "fishAbundanceAndDistribution",
+    "Myxini": "fishAbundanceAndDistribution",
+    "Petromyzonti": "fishAbundanceAndDistribution",
+    "Holocephali": "fishAbundanceAndDistribution",
+    "Chondrostei": "fishAbundanceAndDistribution",
+    "Ichthyostraca": "fishAbundanceAndDistribution",
+    # Marine turtles, birds, mammals
+    "Mammalia": "marineTurtlesBirdsMammalsAbundanceAndDistribution",
+    "Aves": "marineTurtlesBirdsMammalsAbundanceAndDistribution",
+    "Reptilia": "marineTurtlesBirdsMammalsAbundanceAndDistribution",
+    # Phytoplankton
+    "Bacillariophyceae": "phytoplanktonBiomassAndDiversity",
+    "Dinophyceae": "phytoplanktonBiomassAndDiversity",
+    "Coscinodiscophyceae": "phytoplanktonBiomassAndDiversity",
+    "Mediophyceae": "phytoplanktonBiomassAndDiversity",
+    "Fragilariophyceae": "phytoplanktonBiomassAndDiversity",
+    "Cyanophyceae": "phytoplanktonBiomassAndDiversity",
+    "Prymnesiophyceae": "phytoplanktonBiomassAndDiversity",
+    "Coccolithophyceae": "phytoplanktonBiomassAndDiversity",
+    "Chrysophyceae": "phytoplanktonBiomassAndDiversity",
+    "Cryptophyceae": "phytoplanktonBiomassAndDiversity",
+    "Prasinophyceae": "phytoplanktonBiomassAndDiversity",
+    "Raphidophyceae": "phytoplanktonBiomassAndDiversity",
+    "Dictyochophyceae": "phytoplanktonBiomassAndDiversity",
+    "Euglenoidea": "phytoplanktonBiomassAndDiversity",
+    "Euglenophyceae": "phytoplanktonBiomassAndDiversity",
+    "Xanthophyceae": "phytoplanktonBiomassAndDiversity",
+    "Chlorophyceae": "phytoplanktonBiomassAndDiversity",
+    "Chlorodendrophyceae": "phytoplanktonBiomassAndDiversity",
+    "Trebouxiophyceae": "phytoplanktonBiomassAndDiversity",
+    "Zygnematophyceae": "phytoplanktonBiomassAndDiversity",
+    # Zooplankton (includes many protist microzooplankton & foraminifera groups)
+    "Hexanauplia": "zooplanktonBiomassAndDiversity",
+    "Copepoda": "zooplanktonBiomassAndDiversity",
+    "Branchiopoda": "zooplanktonBiomassAndDiversity",
+    "Ostracoda": "zooplanktonBiomassAndDiversity",
+    "Scyphozoa": "zooplanktonBiomassAndDiversity",
+    "Hydrozoa": "zooplanktonBiomassAndDiversity",
+    "Appendicularia": "zooplanktonBiomassAndDiversity",
+    "Thaliacea": "zooplanktonBiomassAndDiversity",
+    "Sagittoidea": "zooplanktonBiomassAndDiversity",
+    "Choanoflagellatea": "zooplanktonBiomassAndDiversity",
+    "Oligotrichea": "zooplanktonBiomassAndDiversity",
+    "Heterotrichea": "zooplanktonBiomassAndDiversity",
+    "Prostomatea": "zooplanktonBiomassAndDiversity",
+    "Oligohymenophorea": "zooplanktonBiomassAndDiversity",
+    "Globothalamea": "zooplanktonBiomassAndDiversity",
+    "Tubothalamea": "zooplanktonBiomassAndDiversity",
+    "Nodosariata": "zooplanktonBiomassAndDiversity",
+    "Monothalamea": "zooplanktonBiomassAndDiversity",
+    "Tubulinea": "zooplanktonBiomassAndDiversity",
+    "Foraminifera incertae sedis": "zooplanktonBiomassAndDiversity",
+    # Microbes
+    "Alphaproteobacteria": "microbeBiomassAndDiversity",
+    "Betaproteobacteria": "microbeBiomassAndDiversity",
+    "Gammaproteobacteria": "microbeBiomassAndDiversity",
+    "Deltaproteobacteria": "microbeBiomassAndDiversity",
+    "Epsilonproteobacteria": "microbeBiomassAndDiversity",
+    "Flavobacteria": "microbeBiomassAndDiversity",
+    "Actinobacteria": "microbeBiomassAndDiversity",
+    "Bacilli": "microbeBiomassAndDiversity",
+    "Bacili": "microbeBiomassAndDiversity",
+    "Cytophagia": "microbeBiomassAndDiversity",
+    "Sphingobacteria": "microbeBiomassAndDiversity",
+    "Gemmatimonadetes(class)": "microbeBiomassAndDiversity",
+    "Aquificae": "microbeBiomassAndDiversity",
+    "Methanomicrobia": "microbeBiomassAndDiversity",
+    # Macroalgae
+    "Phaeophyceae": "macroalgalCanopyCoverAndComposition",
+    "Florideophyceae": "macroalgalCanopyCoverAndComposition",
+    "Ulvophyceae": "macroalgalCanopyCoverAndComposition",
+    "Bangiophyceae": "macroalgalCanopyCoverAndComposition",
+    "Compsopogonophyceae": "macroalgalCanopyCoverAndComposition",
+    # Hard coral
+    "Anthozoa": "hardCoralCoverAndComposition",
+    "Hexacorallia": "hardCoralCoverAndComposition",
+    "Octocorallia": "hardCoralCoverAndComposition",
+    # Invertebrates (catch-all for many marine invertebrate classes)
+    "Gastropoda": "invertebrateAbundanceAndDistribution",
+    "Bivalvia": "invertebrateAbundanceAndDistribution",
+    "Cephalopoda": "invertebrateAbundanceAndDistribution",
+    "Polychaeta": "invertebrateAbundanceAndDistribution",
+    "Clitellata": "invertebrateAbundanceAndDistribution",
+    "Echinoidea": "invertebrateAbundanceAndDistribution",
+    "Asteroidea": "invertebrateAbundanceAndDistribution",
+    "Ophiuroidea": "invertebrateAbundanceAndDistribution",
+    "Holothuroidea": "invertebrateAbundanceAndDistribution",
+    "Crinoidea": "invertebrateAbundanceAndDistribution",
+    "Malacostraca": "invertebrateAbundanceAndDistribution",
+    "Thecostraca": "invertebrateAbundanceAndDistribution",
+    "Demospongiae": "invertebrateAbundanceAndDistribution",
+    "Calcarea": "invertebrateAbundanceAndDistribution",
+    "Hexactinellida": "invertebrateAbundanceAndDistribution",
+    "Ascidiacea": "invertebrateAbundanceAndDistribution",
+    "Tentaculata": "invertebrateAbundanceAndDistribution",
+    "Gymnolaemata": "invertebrateAbundanceAndDistribution",
+    "Stenolaemata": "invertebrateAbundanceAndDistribution",
+    "Polyplacophora": "invertebrateAbundanceAndDistribution",
+    "Scaphopoda": "invertebrateAbundanceAndDistribution",
+    "Sipunculidea": "invertebrateAbundanceAndDistribution",
+    "Pycnogonida": "invertebrateAbundanceAndDistribution",
+    "Hexapoda": "invertebrateAbundanceAndDistribution",
+    "Arachnida": "invertebrateAbundanceAndDistribution",
+    "Turbellaria": "invertebrateAbundanceAndDistribution",
+    "Chromadorea": "invertebrateAbundanceAndDistribution",
+    "Monogenea": "invertebrateAbundanceAndDistribution",
+    "Hoplonemertea": "invertebrateAbundanceAndDistribution",
+    # Seagrass — Magnoliopsida covers most seagrasses (Zostera, Posidonia, etc.)
+    "Magnoliopsida": "seagrassCoverAndComposition",
+    "Liliopsida": "seagrassCoverAndComposition",
+    # Other
+    "Amphibia": "other",
+}
 
 
 def add_fr(text):
@@ -97,6 +220,59 @@ OBIS_TO_CIOOS_ROLE = {
 }
 
 
+def fetch_eovs_from_taxonomy(dataset_id):
+    """Fetch taxonomic classes for an OBIS dataset and map them to CIOOS EOVs.
+
+    Calls the OBIS facet API to get class-level taxonomy, then maps each class
+    to a CIOOS Essential Ocean Variable using TAXON_CLASS_TO_EOV.
+    Returns a deduplicated list of EOV codes.
+    """
+    if not dataset_id:
+        return []
+
+    try:
+        response = requests.get(
+            OBIS_FACET_URL,
+            params={"datasetid": dataset_id, "facets": "class"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (requests.RequestException, ValueError) as e:
+        logger.warning(f"Failed to fetch taxonomy facets for {dataset_id}: {e}")
+        return []
+
+    classes = data.get("results", {}).get("class", [])
+    if not classes:
+        logger.info(f"No taxonomic classes found for dataset {dataset_id}")
+        return []
+
+    eovs = set()
+    unmapped = []
+    for entry in classes:
+        taxon_class = entry.get("key", "")
+        eov = TAXON_CLASS_TO_EOV.get(taxon_class)
+        if eov:
+            eovs.add(eov)
+        else:
+            unmapped.append(taxon_class)
+
+    if unmapped:
+        logger.info(
+            f"Dataset {dataset_id}: unmapped taxonomic classes: {unmapped}"
+        )
+
+    # CIOOS requires at least one EOV; if we can't map any taxonomy classes
+    # (or if a dataset only contains odd/terrestrial classes), fall back to "other".
+    if not eovs:
+        logger.warning(
+            f"Dataset {dataset_id}: no EOVs mapped from taxonomy; falling back to ['other']"
+        )
+        return ["other"]
+
+    return sorted(eovs)
+
+
 def map_obis_role_to_cioos(obis_role):
     """Map an OBIS EML role/type to a valid CIOOS ISO 19115 role code.
 
@@ -139,6 +315,14 @@ def convert_contacts(obis_contacts):
     for contact in obis_contacts:
         given_name = contact.get("givenname", "")
         last_name = contact.get("surname", "")
+        org_name = contact.get("organization", "")
+
+        # Skip contacts with no usable identity — they would produce empty
+        # individual/organization dicts that crash the XML template after
+        # scrub_dict removes all the empty values.
+        if not given_name and not last_name and not org_name:
+            logger.debug(f"Skipping contact with no name or organization: {contact}")
+            continue
 
         # Build full name
         full_name = ""
@@ -156,7 +340,7 @@ def convert_contacts(obis_contacts):
             "indOrcid": "",
             "inCitation": True,  # Default to true for creators/authors
             "role": [map_obis_role_to_cioos(contact.get("type", ""))],
-            "orgName": contact.get("organization", ""),
+            "orgName": org_name,
             "orgAddress": "",
             "orgCity": "",
             "orgCountry": "",
@@ -164,13 +348,12 @@ def convert_contacts(obis_contacts):
             "orgURL": contact.get("url", ""),
         }
 
-        # For contacts with email, add it with different field name
         if contact.get("email"):
             cioos_contact["indEmail"] = contact.get("email")
 
-        # Add position if available
+        # indPosition is the field name firebase_to_cioos expects
         if contact.get("position"):
-            cioos_contact["position"] = contact.get("position")
+            cioos_contact["indPosition"] = contact.get("position")
 
         cioos_contacts.append(cioos_contact)
 
@@ -326,7 +509,9 @@ def map_obis_to_cioos(obis_data):
     cioos_data["timeFirstPublished"] = cioos_data[
         "datePublished"
     ]  # Use same as datePublished
-    cioos_data["eov"] = []  # Essential Ocean Variables - can't map from OBIS
+    # Derive EOVs from OBIS taxonomy via the facet API
+    dataset_id = obis_data.get("id")
+    cioos_data["eov"] = fetch_eovs_from_taxonomy(dataset_id)
     cioos_data["platforms"] = []  # Platform information not available
     cioos_data["projects"] = []  # Project information not available
     cioos_data["region"] = ""  # Geographic region classification

--- a/cioos_metadata_conversion/record.py
+++ b/cioos_metadata_conversion/record.py
@@ -14,6 +14,7 @@ from cioos_metadata_conversion import (
     xml,
 )
 from cioos_metadata_conversion.load_from import datacite as load_from_datacite
+from cioos_metadata_conversion.load_from import obis as load_from_obis
 
 SOURCE_FILE_EXTENSIONS = (".json", ".yaml", ".yml")
 
@@ -40,6 +41,7 @@ class InputSchemas(Enum):
     CIOOS = "CIOOS"
     firebase = "firebase"
     doi = "doi"
+    obis = "obis"
 
 
 class Record:
@@ -81,6 +83,16 @@ class Record:
             # Check if it's a DOI URL
             if "doi.org/" in self.source:
                 self.load_from_doi(self.source)
+            elif "obis.org/" in self.source:
+                # Handle OBIS URLs e.g. https://obis.org/dataset/{id} or API urls
+                # Extract ID from URL
+                if "dataset/" in self.source:
+                    dataset_id = (
+                        self.source.split("dataset/")[-1].split("?")[0].strip("/")
+                    )
+                    self.load_from_obis(dataset_id)
+                else:
+                    self.load_from_url(self.source)
             else:
                 # Load from URL
                 self.load_from_url(self.source)
@@ -89,6 +101,8 @@ class Record:
         elif isinstance(self.source, str) and self._is_valid_doi(self.source):
             # Load from DOI
             self.load_from_doi(self.source)
+        elif self.schema == InputSchemas.obis:
+            self.load_from_obis(self.source)
         elif isinstance(self.source, str):
             self.load_from_text(self.source)
         else:
@@ -141,6 +155,21 @@ class Record:
             logger.error(f"Failed to load metadata from DOI: {e}")
             raise
 
+    def load_from_obis(self, obis_id):
+        """
+        Load metadata from OBIS using the OBIS API.
+
+        Args:
+            obis_id: OBIS dataset ID (UUID)
+        """
+        try:
+            self.metadata = load_from_obis.retrieve_obis_metadata(obis_id)
+            self.schema = InputSchemas.firebase
+            logger.info(f"Successfully loaded metadata from OBIS: {obis_id}")
+        except Exception as e:
+            logger.error(f"Failed to load metadata from OBIS: {e}")
+            raise
+
     def _is_valid_doi(self, source):
         """
         Check if the source string is a valid DOI format.
@@ -152,9 +181,9 @@ class Record:
 
         # Check for common DOI patterns
         return (
-            source.startswith("10.") or
-            source.startswith("doi:10.") or
-            source.startswith("DOI:10.")
+            source.startswith("10.")
+            or source.startswith("doi:10.")
+            or source.startswith("DOI:10.")
         )
 
     def convert_to_cioos_schema(self):
@@ -169,6 +198,10 @@ class Record:
             self.schema = InputSchemas.CIOOS
         elif self.schema == InputSchemas.doi:
             # DOI metadata is loaded as Firebase, then convert to CIOOS
+            self.metadata = firebase_to_cioos.record_json_to_yaml(self.metadata)
+            self.schema = InputSchemas.CIOOS
+        elif self.schema == InputSchemas.obis:
+            # OBIS metadata is loaded as Firebase, then convert to CIOOS
             self.metadata = firebase_to_cioos.record_json_to_yaml(self.metadata)
             self.schema = InputSchemas.CIOOS
         else:

--- a/tests/test_load_from_obis.py
+++ b/tests/test_load_from_obis.py
@@ -1,0 +1,648 @@
+"""Unit tests for OBIS metadata loading and EOV tagging.
+
+Focus: the non-biodiversity EOV tagging path added on top of
+fetch_eovs_from_taxonomy — _map_measurement_pair,
+fetch_eovs_from_measurements, and the merge in map_obis_to_cioos.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from cioos_metadata_conversion.load_from.obis import (
+    _map_measurement_pair,
+    fetch_eovs_from_measurements,
+    fetch_eovs_from_taxonomy,
+    map_obis_to_cioos,
+)
+
+
+class TestMeasurementMapping:
+    """_map_measurement_pair: P01 lookup + free-text fallback + surface rule."""
+
+    def test_p01_code_extracted_from_uri(self):
+        assert (
+            _map_measurement_pair(
+                "", "http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/"
+            )
+            == "subSurfaceTemperature"
+        )
+
+    def test_p01_code_extracted_without_trailing_slash(self):
+        assert (
+            _map_measurement_pair(
+                "", "http://vocab.nerc.ac.uk/collection/P01/current/PSALPR01"
+            )
+            == "subSurfaceSalinity"
+        )
+
+    def test_text_fallback_when_id_empty(self):
+        assert (
+            _map_measurement_pair("Chlorophyll a concentration", "")
+            == "oceanColour"
+        )
+
+    def test_surface_temperature_disambiguation(self):
+        assert (
+            _map_measurement_pair("Sea surface temperature", "")
+            == "seaSurfaceTemperature"
+        )
+
+    def test_surface_salinity_disambiguation(self):
+        assert (
+            _map_measurement_pair("Sea surface salinity", "")
+            == "seaSurfaceSalinity"
+        )
+
+    def test_subsurface_default_without_surface_token(self):
+        assert (
+            _map_measurement_pair("Water temperature at depth", "")
+            == "subSurfaceTemperature"
+        )
+
+    def test_p01_id_overrides_contradictory_text(self):
+        assert (
+            _map_measurement_pair(
+                "some unrelated label",
+                "http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/",
+            )
+            == "subSurfaceTemperature"
+        )
+
+    def test_unknown_measurement_returns_none(self):
+        assert _map_measurement_pair("Net sonde voltage", "") is None
+
+    def test_empty_pair_returns_none(self):
+        assert _map_measurement_pair("", "") is None
+
+    def test_unknown_p01_falls_through_to_text(self):
+        # Unknown P01 code shouldn't crash; text fallback still applies
+        assert (
+            _map_measurement_pair(
+                "Oxygen concentration",
+                "http://vocab.nerc.ac.uk/collection/P01/current/UNKNOW01/",
+            )
+            == "oxygen"
+        )
+
+    def test_ph_abbreviation_does_not_match_chlorophyll(self):
+        # Regression: "ph" substring previously matched "chlorophyll"
+        assert (
+            _map_measurement_pair("Chlorophyll a concentration", "")
+            == "oceanColour"
+        )
+
+    def test_ph_abbreviation_does_not_match_phytoplankton(self):
+        assert _map_measurement_pair("Phytoplankton biomass", "") is None
+
+    def test_ph_matches_as_standalone_token(self):
+        assert _map_measurement_pair("pH of seawater", "") == "inorganicCarbon"
+
+    # --- Extended EOV coverage ---
+
+    def test_wind_does_not_emit_ocean_surface_stress(self):
+        # Wind is an input to the stress product (τ = ρ·Cd·|U|·U), not
+        # the EOV itself. Zero curators tagged oceanSurfaceStress across
+        # the audit corpus, including on datasets with bare wind eMoF.
+        # Both the P01 codes (EWSBZZ01 / EWDAZZ01) and the free-text
+        # wind keys are unmapped. If a platform publishes a derived
+        # surface-stress parameter, the P01 table needs that code added.
+        assert (
+            _map_measurement_pair(
+                "", "http://vocab.nerc.ac.uk/collection/P01/current/EWSBZZ01/"
+            )
+            is None
+        )
+        assert (
+            _map_measurement_pair(
+                "", "http://vocab.nerc.ac.uk/collection/P01/current/EWDAZZ01/"
+            )
+            is None
+        )
+        assert _map_measurement_pair("Wind speed", "") is None
+        assert _map_measurement_pair("Wind direction", "") is None
+        assert _map_measurement_pair("Vent à la pose | Initial wind speed", "") is None
+
+    def test_bare_beaufort_text_does_not_emit_sea_state(self):
+        # Bare "Beaufort Scale" / "Vent (Beaufort)" in OBIS eMoF are
+        # ancillary wind observations, not wave-height measurements. GOOS
+        # seaState scope is waves; Beaufort-only labels are too coarse and
+        # curator tagging is inconsistent. The WMO P01 codes still map.
+        assert _map_measurement_pair("Beaufort Scale", "") is None
+        assert _map_measurement_pair("Vent (Beaufort) | Wind (Beaufort)", "") is None
+
+    def test_snake_case_french_temp_and_salinity(self):
+        # Some Comité ZIP Rive Nord de l'Estuaire datasets ship eMoF with
+        # ASCII snake_case French labels. Underscore is a word character,
+        # so regex boundaries block "temperature"/"salinity" from leaking
+        # into these — they need explicit keys.
+        assert _map_measurement_pair("temp_eau", "") == "subSurfaceTemperature"
+        assert _map_measurement_pair("salinite_psu", "") == "subSurfaceSalinity"
+        # Air temp snake-case must stay blocked by the atmospheric guard.
+        assert _map_measurement_pair("temp_air", "") is None
+
+    def test_sea_state_p01_code(self):
+        assert (
+            _map_measurement_pair(
+                "", "http://vocab.nerc.ac.uk/collection/P01/current/WMOCSSXX/"
+            )
+            == "seaState"
+        )
+
+    def test_wave_height_maps_to_sea_state(self):
+        assert _map_measurement_pair("Wave height", "") == "seaState"
+
+    def test_surface_current_maps_to_surface_currents(self):
+        assert (
+            _map_measurement_pair("Surface current direction", "")
+            == "surfaceCurrents"
+        )
+
+    def test_generic_current_speed_maps_to_subsurface(self):
+        assert (
+            _map_measurement_pair("Current speed at 50m", "")
+            == "subSurfaceCurrents"
+        )
+
+    def test_tide_height_maps_to_sea_surface_height(self):
+        assert _map_measurement_pair("Tide height", "") == "seaSurfaceHeight"
+        assert (
+            _map_measurement_pair("Hauteur de la marée | Tide height", "")
+            == "seaSurfaceHeight"
+        )
+        assert _map_measurement_pair("Water level", "") == "seaSurfaceHeight"
+
+    def test_tide_phase_does_not_map_to_sea_surface_height(self):
+        # "Tide level" / "Stade de la marée" are categorical phase labels
+        # (high/low/ebb/flood), not numeric heights.
+        assert _map_measurement_pair("Tide level", "") is None
+        assert _map_measurement_pair("Stade de la marée | Tide level", "") is None
+
+    def test_sea_surface_height_p01_codes(self):
+        assert (
+            _map_measurement_pair(
+                "", "http://vocab.nerc.ac.uk/collection/P01/current/ASLVZZ01/"
+            )
+            == "seaSurfaceHeight"
+        )
+        assert (
+            _map_measurement_pair(
+                "", "http://vocab.nerc.ac.uk/collection/P01/current/ASLVTD01/"
+            )
+            == "seaSurfaceHeight"
+        )
+
+    def test_ice_cover_maps_to_sea_ice(self):
+        assert _map_measurement_pair("Ice cover", "") == "seaIce"
+
+    def test_hydrophone_maps_to_ocean_sound(self):
+        assert (
+            _map_measurement_pair("Hydrophone recording", "") == "oceanSound"
+        )
+
+    def test_microplastic_maps_to_marine_debris(self):
+        assert (
+            _map_measurement_pair("Microplastic concentration", "")
+            == "marineDebris"
+        )
+
+    def test_delta_13c_maps_to_stable_carbon_isotopes(self):
+        assert (
+            _map_measurement_pair("δ13C of POM", "")
+            == "stableCarbonIsotopes"
+        )
+
+    def test_n2o_maps_to_nitrous_oxide(self):
+        assert _map_measurement_pair("N2O concentration", "") == "nitrousOxide"
+
+    def test_per_cell_poc_does_not_emit_particulate_matter(self):
+        # Flow-cytometry label — per-cell carbon content is phytoplankton
+        # biomass data, not bulk particulates.
+        assert (
+            _map_measurement_pair("Particulate Organic Carbon per cell", "")
+            is None
+        )
+
+    def test_per_cell_p01_code_suppressed(self):
+        assert (
+            _map_measurement_pair(
+                "Particulate Organic Carbon per cell",
+                "http://vocab.nerc.ac.uk/collection/P01/current/MAOCCB11/",
+            )
+            is None
+        )
+
+    def test_bulk_particulate_carbon_still_maps(self):
+        # Control — bulk POC (no "per cell") should still emit.
+        assert (
+            _map_measurement_pair("Particulate organic carbon", "")
+            == "particulateMatter"
+        )
+
+    def test_cfc11_maps_to_transient_tracers(self):
+        assert _map_measurement_pair("CFC-11", "") == "transientTracers"
+
+
+class TestFetchEovsFromMeasurements:
+    """fetch_eovs_from_measurements: extensions gate + API call + mapping."""
+
+    def test_empty_dataset_id_returns_empty(self):
+        assert fetch_eovs_from_measurements("") == []
+        assert fetch_eovs_from_measurements(None) == []
+
+    def test_short_circuits_when_no_emof_extension(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get"
+        ) as mock_get:
+            result = fetch_eovs_from_measurements(
+                "abc-123", extensions=["Occurrence"]
+            )
+            mock_get.assert_not_called()
+            assert result == []
+
+    def test_short_circuits_on_empty_extensions_list(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get"
+        ) as mock_get:
+            result = fetch_eovs_from_measurements("abc-123", extensions=[])
+            mock_get.assert_not_called()
+            assert result == []
+
+    def test_runs_when_extensions_is_none(self):
+        # None means "caller didn't tell us" — fall through to the API call.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status.return_value = None
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ) as mock_get:
+            result = fetch_eovs_from_measurements("abc-123", extensions=None)
+            mock_get.assert_called_once()
+            assert result == []
+
+    def test_maps_ctd_measurements(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "mof": [
+                        {
+                            "measurementType": "Sea water temperature",
+                            "measurementTypeID": (
+                                "http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/"
+                            ),
+                        },
+                        {
+                            "measurementType": "Practical salinity",
+                            "measurementTypeID": (
+                                "http://vocab.nerc.ac.uk/collection/P01/current/PSALPR01/"
+                            ),
+                        },
+                        {
+                            "measurementType": "Dissolved oxygen",
+                            "measurementTypeID": (
+                                "http://vocab.nerc.ac.uk/collection/P01/current/DOXYZZXX/"
+                            ),
+                        },
+                    ]
+                }
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ):
+            result = fetch_eovs_from_measurements(
+                "abc-123", extensions=["ExtendedMeasurementOrFact"]
+            )
+        assert result == ["oxygen", "subSurfaceSalinity", "subSurfaceTemperature"]
+
+    def test_deduplicates_across_occurrences(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"mof": [{"measurementType": "Temperature", "measurementTypeID": ""}]},
+                {"mof": [{"measurementType": "Temperature", "measurementTypeID": ""}]},
+                {"mof": [{"measurementType": "Salinity", "measurementTypeID": ""}]},
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ):
+            result = fetch_eovs_from_measurements(
+                "abc-123", extensions=["MeasurementOrFact"]
+            )
+        assert result == ["subSurfaceSalinity", "subSurfaceTemperature"]
+
+    def test_api_error_returns_empty(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            result = fetch_eovs_from_measurements(
+                "abc-123", extensions=["ExtendedMeasurementOrFact"]
+            )
+        assert result == []
+
+    def test_invalid_json_returns_empty(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.side_effect = ValueError("not json")
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ):
+            result = fetch_eovs_from_measurements(
+                "abc-123", extensions=["ExtendedMeasurementOrFact"]
+            )
+        assert result == []
+
+    def test_unmapped_measurements_silently_dropped(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "mof": [
+                        {"measurementType": "Net sonde voltage", "measurementTypeID": ""},
+                        {"measurementType": "Temperature", "measurementTypeID": ""},
+                    ]
+                }
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ):
+            result = fetch_eovs_from_measurements(
+                "abc-123", extensions=["ExtendedMeasurementOrFact"]
+            )
+        assert result == ["subSurfaceTemperature"]
+
+
+class TestFetchEovsFromTaxonomy:
+    """Zooplankton and cover-EOV threshold gates in fetch_eovs_from_taxonomy."""
+
+    @staticmethod
+    def _mock_facet(class_buckets):
+        resp = MagicMock()
+        resp.json.return_value = {"results": {"class": class_buckets}}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_zoo_emitted_when_core_classes_dominate(self):
+        buckets = [
+            {"key": "Copepoda", "records": 1000},
+            {"key": "Sagittoidea", "records": 100},
+            {"key": "Teleostei", "records": 50},
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("plankton-net")
+        assert "zooplanktonBiomassAndDiversity" in result
+
+    def test_zoo_suppressed_when_only_gelatinous_bycatch(self):
+        # Fish-dominated trawl with jellyfish bycatch — no core zoo class.
+        buckets = [
+            {"key": "Teleostei", "records": 1000},
+            {"key": "Scyphozoa", "records": 200},
+            {"key": "Hydrozoa", "records": 50},
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("trawl-bycatch")
+        assert "zooplanktonBiomassAndDiversity" not in result
+        assert "fishAbundanceAndDistribution" in result
+
+    def test_zoo_suppressed_when_core_below_threshold(self):
+        # Core class present but at <5% of dataset records.
+        buckets = [
+            {"key": "Teleostei", "records": 1000},
+            {"key": "Copepoda", "records": 10},  # 1% — below threshold
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("fish-with-trace-copepods")
+        assert "zooplanktonBiomassAndDiversity" not in result
+
+    def test_zoo_emitted_at_threshold(self):
+        # Core class right at 5% boundary — should pass.
+        buckets = [
+            {"key": "Teleostei", "records": 950},
+            {"key": "Copepoda", "records": 50},  # 5% exactly
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("at-threshold")
+        assert "zooplanktonBiomassAndDiversity" in result
+
+    def test_invert_suppressed_in_plankton_net_without_benthic(self):
+        # Bongo/Juday net sample: Copepoda core + larval inverts only.
+        # No benthic indicator class → invertebrate is suppressed.
+        buckets = [
+            {"key": "Copepoda", "records": 1000},
+            {"key": "Malacostraca", "records": 200},  # krill/mysids
+            {"key": "Gastropoda", "records": 150},    # pteropods
+            {"key": "Polychaeta", "records": 80},     # larval
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("plankton-net")
+        assert "zooplanktonBiomassAndDiversity" in result
+        assert "invertebrateAbundanceAndDistribution" not in result
+
+    def test_invert_kept_when_benthic_indicator_present(self):
+        # Same planktonic mix plus Echinoidea — now it's a plankton-tow
+        # that also sampled epifauna, so both EOVs stand.
+        buckets = [
+            {"key": "Copepoda", "records": 1000},
+            {"key": "Malacostraca", "records": 200},
+            {"key": "Echinoidea", "records": 30},  # benthic indicator
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("plankton-plus-epifauna")
+        assert "zooplanktonBiomassAndDiversity" in result
+        assert "invertebrateAbundanceAndDistribution" in result
+
+    def test_invert_kept_when_no_zooplankton_emitted(self):
+        # Pure benthic survey — no zoo signal, rule doesn't fire.
+        buckets = [
+            {"key": "Malacostraca", "records": 500},
+            {"key": "Gastropoda", "records": 200},
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("benthic-survey")
+        assert "invertebrateAbundanceAndDistribution" in result
+        assert "zooplanktonBiomassAndDiversity" not in result
+
+    def test_fungal_and_parasitic_classes_do_not_emit_microbe(self):
+        # These were formerly mapped to microbeBiomassAndDiversity. They
+        # are dropped because fungi in OBIS include many terrestrial
+        # records and parasitic/host-bound protists aren't free-living
+        # marine microbes in the GOOS sense.
+        buckets = [
+            {"key": "Lecanoromycetes", "records": 20},   # lichens
+            {"key": "Agaricomycetes", "records": 10},    # mushrooms
+            {"key": "Conoidasida", "records": 50},       # apicomplexan parasites
+            {"key": "Labyrinthulea", "records": 30},     # slime nets
+            {"key": "Teleostei", "records": 100},        # anchor: keeps result non-empty
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("mixed-shoreline")
+        assert "microbeBiomassAndDiversity" not in result
+
+    def test_bacterial_classes_still_emit_microbe(self):
+        # Control — genuine bacterial classes should still map.
+        buckets = [
+            {"key": "Gammaproteobacteria", "records": 500},
+            {"key": "Flavobacteria", "records": 200},
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("microbial-survey")
+        assert "microbeBiomassAndDiversity" in result
+
+    def test_cnidarian_classes_map_to_invertebrate_not_hardcoral(self):
+        # Octocorallia = soft corals/sea pens. Hexacorallia includes
+        # anemones and black corals alongside Scleractinia. Neither is
+        # specific to hardCoralCoverAndComposition.
+        buckets = [
+            {"key": "Octocorallia", "records": 100},
+            {"key": "Hexacorallia", "records": 50},
+            {"key": "Anthozoa", "records": 25},
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=self._mock_facet(buckets),
+        ):
+            result = fetch_eovs_from_taxonomy("sea-pen-dataset")
+        assert "hardCoralCoverAndComposition" not in result
+        assert "invertebrateAbundanceAndDistribution" in result
+
+
+class TestMapObisToCioosEovMerging:
+    """map_obis_to_cioos merges taxonomy and measurement EOVs correctly."""
+
+    @staticmethod
+    def _minimal_obis_data():
+        return {"id": "dataset-uuid", "extensions": ["ExtendedMeasurementOrFact"]}
+
+    def test_taxonomy_only_passes_through(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_taxonomy",
+            return_value=["fishAbundanceAndDistribution"],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_measurements",
+            return_value=[],
+        ):
+            result = map_obis_to_cioos(self._minimal_obis_data())
+        assert result["eov"] == ["fishAbundanceAndDistribution"]
+
+    def test_other_dropped_when_measurements_exist(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_taxonomy",
+            return_value=["other"],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_measurements",
+            return_value=["seaSurfaceTemperature"],
+        ):
+            result = map_obis_to_cioos(self._minimal_obis_data())
+        assert result["eov"] == ["seaSurfaceTemperature"]
+
+    def test_other_preserved_when_no_measurements(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_taxonomy",
+            return_value=["other"],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_measurements",
+            return_value=[],
+        ):
+            result = map_obis_to_cioos(self._minimal_obis_data())
+        assert result["eov"] == ["other"]
+
+    def test_empty_both_falls_back_to_other(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_taxonomy",
+            return_value=[],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_measurements",
+            return_value=[],
+        ):
+            result = map_obis_to_cioos(self._minimal_obis_data())
+        assert result["eov"] == ["other"]
+
+    def test_biology_and_measurement_eovs_merged(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_taxonomy",
+            return_value=["fishAbundanceAndDistribution", "zooplanktonBiomassAndDiversity"],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_measurements",
+            return_value=["subSurfaceTemperature", "subSurfaceSalinity"],
+        ):
+            result = map_obis_to_cioos(self._minimal_obis_data())
+        assert result["eov"] == [
+            "fishAbundanceAndDistribution",
+            "subSurfaceSalinity",
+            "subSurfaceTemperature",
+            "zooplanktonBiomassAndDiversity",
+        ]
+
+    def test_extensions_passed_to_measurement_fetch(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_taxonomy",
+            return_value=[],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_measurements",
+            return_value=[],
+        ) as mock_measurements:
+            obis_data = {"id": "x", "extensions": ["Occurrence", "ExtendedMeasurementOrFact"]}
+            map_obis_to_cioos(obis_data)
+            mock_measurements.assert_called_once_with(
+                "x", extensions=["Occurrence", "ExtendedMeasurementOrFact"]
+            )
+
+
+# Integration test — hits the live OBIS API. Follows the pattern of
+# test_real_doi in test_load_from_datacite.py. Pick a dataset that carries
+# eMoF measurements (any OBIS landing page listing ExtendedMeasurementOrFact).
+@pytest.mark.parametrize(
+    "dataset_id",
+    [
+        # AZMP-style plankton + CTD dataset from DFO — publicly known to
+        # carry temperature/salinity/chlorophyll in eMoF. Replace if the
+        # integration test becomes flaky against this specific dataset.
+        "4bc13a6a-71a3-4a2d-b23d-3ce50a9aef41",
+    ],
+)
+def test_real_obis_dataset_with_measurements(dataset_id):
+    """Live API check — any of the expected physical EOVs should show up."""
+    eovs = fetch_eovs_from_measurements(dataset_id)
+    # The dataset may or may not actually declare extensions the way we
+    # expect; call without the gate to force the fetch.
+    assert isinstance(eovs, list)

--- a/tests/test_load_from_obis.py
+++ b/tests/test_load_from_obis.py
@@ -11,9 +11,12 @@ import pytest
 import requests
 
 from cioos_metadata_conversion.load_from.obis import (
+    VALID_PLATFORM_LABELS,
     _map_measurement_pair,
+    _match_platform_keywords,
     fetch_eovs_from_measurements,
     fetch_eovs_from_taxonomy,
+    fetch_platforms_from_obis,
     map_obis_to_cioos,
 )
 
@@ -549,6 +552,16 @@ class TestFetchEovsFromTaxonomy:
 class TestMapObisToCioosEovMerging:
     """map_obis_to_cioos merges taxonomy and measurement EOVs correctly."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_platform_fetch(self):
+        # These tests are about EOV merging — skip the live platform
+        # API call by stubbing the inference helper.
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_platforms_from_obis",
+            return_value=[],
+        ):
+            yield
+
     @staticmethod
     def _minimal_obis_data():
         return {"id": "dataset-uuid", "extensions": ["ExtendedMeasurementOrFact"]}
@@ -646,3 +659,250 @@ def test_real_obis_dataset_with_measurements(dataset_id):
     # The dataset may or may not actually declare extensions the way we
     # expect; call without the gate to force the fetch.
     assert isinstance(eovs, list)
+
+
+class TestPlatformKeywordMatching:
+    """_match_platform_keywords: keyword table + specificity dedup."""
+
+    def test_empty_text_returns_empty(self):
+        assert _match_platform_keywords("") == []
+        assert _match_platform_keywords(None) == []
+
+    def test_no_keyword_match_returns_empty(self):
+        assert _match_platform_keywords("Random text with no clue.") == []
+
+    def test_research_vessel_drops_generic_ship(self):
+        # "research vessel" matches both the specific and the generic pattern;
+        # specificity table should drop "ship".
+        assert _match_platform_keywords(
+            "Sampled aboard research vessel CCGS Vector"
+        ) == ["research vessel"]
+
+    def test_fishing_vessel_drops_generic_ship(self):
+        assert _match_platform_keywords("Hauled aboard a fishing vessel") == [
+            "fishing vessel"
+        ]
+
+    def test_bare_vessel_maps_to_ship(self):
+        assert _match_platform_keywords("Collected from vessel during transit") == [
+            "ship"
+        ]
+
+    def test_subsurface_mooring_drops_generic_mooring(self):
+        assert _match_platform_keywords(
+            "Instruments on a subsurface mooring at 100m"
+        ) == ["subsurface mooring"]
+
+    def test_moored_surface_buoy_drops_generic_mooring(self):
+        assert _match_platform_keywords(
+            "ADCP attached to a moored surface buoy"
+        ) == ["moored surface buoy"]
+
+    def test_bare_mooring_keeps_label(self):
+        assert _match_platform_keywords("Sampled from a long-term mooring") == [
+            "mooring"
+        ]
+
+    def test_surface_glider_distinct_from_subsurface(self):
+        assert _match_platform_keywords("Deployed surface glider") == [
+            "surface gliders"
+        ]
+
+    def test_bare_glider_defaults_to_subsurface(self):
+        assert _match_platform_keywords("Slocum glider mission") == [
+            "sub-surface gliders"
+        ]
+
+    def test_argo_float_maps_to_profiling_float(self):
+        # And drops the generic drifting-surface-float hit even though
+        # "float" overlaps with the float family.
+        assert _match_platform_keywords("Argo float profile") == [
+            "drifting subsurface profiling float"
+        ]
+
+    def test_rov_maps_to_propelled_unmanned_submersible(self):
+        assert _match_platform_keywords(
+            "Video observations from ROV during dive"
+        ) == ["propelled unmanned submersible"]
+
+    def test_auv_maps_to_autonomous_underwater_vehicle(self):
+        assert _match_platform_keywords("REMUS AUV survey transect") == [
+            "autonomous underwater vehicle"
+        ]
+
+    def test_diver_keywords(self):
+        assert _match_platform_keywords("SCUBA divers on transect") == ["diver"]
+
+    def test_intertidal_marsh_maps_to_beach(self):
+        # Salt-marsh dataset (the user's working example).
+        assert _match_platform_keywords(
+            "Sampling along the salt marsh shoreline"
+        ) == ["beach/intertidal zone structure"]
+
+    def test_seafloor_maps_to_fixed_benthic_node(self):
+        assert _match_platform_keywords("Benthic lander on seafloor") == [
+            "fixed benthic node"
+        ]
+
+    def test_uav_drops_generic_aeroplane(self):
+        assert _match_platform_keywords("Aerial survey from UAV / drone") == [
+            "unmanned aerial vehicle"
+        ]
+
+    def test_helicopter_drops_generic_aeroplane(self):
+        assert _match_platform_keywords(
+            "Aerial photo survey from helicopter"
+        ) == ["helicopter"]
+
+    def test_satellite_keyword(self):
+        assert _match_platform_keywords("Derived from satellite imagery") == [
+            "satellite"
+        ]
+
+    def test_case_insensitive(self):
+        assert _match_platform_keywords("RESEARCH VESSEL") == ["research vessel"]
+
+    def test_multiple_distinct_platforms_kept(self):
+        # A benthic survey combining ROV + divers should emit both.
+        result = _match_platform_keywords(
+            "Habitat survey by ROV and accompanying SCUBA divers"
+        )
+        assert set(result) == {"propelled unmanned submersible", "diver"}
+
+    def test_every_table_label_is_in_vocab(self):
+        # Guardrail: the keyword table must never emit a label that the
+        # CIOOS form wouldn't accept.
+        from cioos_metadata_conversion.load_from.obis import (
+            _PLATFORM_KEYWORD_TABLE,
+        )
+
+        for _pattern, label in _PLATFORM_KEYWORD_TABLE:
+            assert label in VALID_PLATFORM_LABELS, (
+                f"{label!r} is not a valid CIOOS platform label_en — "
+                f"check resources/platforms.json"
+            )
+
+
+class TestFetchPlatformsFromObis:
+    """fetch_platforms_from_obis: API sampling + samplingProtocol → label."""
+
+    def test_empty_dataset_id_returns_empty(self):
+        assert fetch_platforms_from_obis("") == []
+        assert fetch_platforms_from_obis(None) == []
+
+    def test_no_occurrences_returns_empty(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status.return_value = None
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ):
+            assert fetch_platforms_from_obis("abc-123") == []
+
+    def test_api_error_returns_empty(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            assert fetch_platforms_from_obis("abc-123") == []
+
+    def test_blank_sampling_protocol_returns_empty(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"samplingProtocol": "", "basisOfRecord": "HumanObservation"},
+                {"samplingProtocol": None, "basisOfRecord": "HumanObservation"},
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ):
+            assert fetch_platforms_from_obis("abc-123") == []
+
+    def test_single_protocol_returns_single_platform(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"samplingProtocol": "Sampled aboard research vessel CCGS Vector"}
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ):
+            result = fetch_platforms_from_obis("abc-123")
+        assert result == [
+            {
+                "id": "obis-platform-1",
+                "type": "research vessel",
+                "description": {"en": "", "fr": ""},
+            }
+        ]
+
+    def test_mixed_protocols_emit_multiple_platforms(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"samplingProtocol": "ROV survey"},
+                {"samplingProtocol": "SCUBA divers on transect"},
+                # duplicate text should not produce a third entry
+                {"samplingProtocol": "ROV survey"},
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.requests.get",
+            return_value=mock_response,
+        ):
+            result = fetch_platforms_from_obis("abc-123")
+        types = {p["type"] for p in result}
+        assert types == {"propelled unmanned submersible", "diver"}
+        # Deterministic IDs starting from 1.
+        assert [p["id"] for p in result] == [
+            f"obis-platform-{i + 1}" for i in range(len(result))
+        ]
+
+
+class TestMapObisToCioosPlatforms:
+    """map_obis_to_cioos wires the platform inference into the record."""
+
+    def test_no_platforms_sets_noPlatform_true(self):
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_taxonomy",
+            return_value=[],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_measurements",
+            return_value=[],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_platforms_from_obis",
+            return_value=[],
+        ):
+            result = map_obis_to_cioos({"id": "x"})
+        assert result["platforms"] == []
+        assert result["noPlatform"] is True
+
+    def test_platforms_present_sets_noPlatform_false(self):
+        platforms = [
+            {
+                "id": "obis-platform-1",
+                "type": "mooring",
+                "description": {"en": "", "fr": ""},
+            }
+        ]
+        with patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_taxonomy",
+            return_value=[],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_eovs_from_measurements",
+            return_value=[],
+        ), patch(
+            "cioos_metadata_conversion.load_from.obis.fetch_platforms_from_obis",
+            return_value=platforms,
+        ):
+            result = map_obis_to_cioos({"id": "x"})
+        assert result["platforms"] == platforms
+        assert result["noPlatform"] is False


### PR DESCRIPTION
# feat: Add support for converting OBIS metadata to ISO19115-3

## Description
This PR adds functionality to retrieve metadata directly from OBIS (Ocean Biodiversity Information System) and convert it 

## Key Changes
- **New Loader Module**: Added `cioos_metadata_conversion/load_from/obis.py` to handle fetching dataset metadata from the OBIS API and mapping it to the internal CIOOS schema. This includes logic for parsing WKT spatial extents and mapping contact roles.
- **Record Class Updates**: Updated `Record` class in `record.py` to support the new `obis` input schema. It can now auto-detect OBIS URLs or accept an OBIS dataset UUID directly.
- **CLI Improvements**: Adjusted `__main__.py` to allow passing non-file inputs (like UUIDs) when using `doi` or `obis` schemas, bypassing the default file globbing behavior.

## Usage
You can now convert an OBIS record by providing its UUID or URL:

```bash
cioos_metadata_conversion convert \
  -i a6155d3d-48b8-4778-83aa-776b459a75d1 \
  -o output.xml \
  -f iso19115-3_xml \
  --input-schema obis
```